### PR TITLE
Add paginated post conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable project changes will be documented here.
 
 ## Unreleased
 
+### Added
+
+- Permanent post links with a responsive full-conversation view, chronological
+  20-comment pages, and policy-filtered access to older replies.
+
 ### Changed
 
 - Dependabot now groups only compatible minor and patch dependency updates;

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
 - Expiring email invitations for restricted Spaces with hashed tokens and verified-account matching.
 - Owner transfer, moderator role changes, reason-required member removal, and an auditable management log.
 - A chronological, non-algorithmic feed.
-- Membership-protected comments with a compact responsive conversation UI.
+- Membership-protected comments with compact feed previews, permanent post
+  links, and a full visibility-filtered paginated conversation view.
 - Private post and comment reporting with allowlisted reasons, duplicate protection, and separate rate limits.
 - A unified, policy-backed moderator queue with documented decisions, content hide/restore behavior, and append-only Space audit entries.
 - Stable member handles, editable profiles with headlines, real visible

--- a/app/Community/CommunityFeed.php
+++ b/app/Community/CommunityFeed.php
@@ -51,7 +51,7 @@ final class CommunityFeed
     }
 
     /**
-     * @return list<array{id: int, body: string, publishedAt: string|null, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, comments: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string}}>
+     * @return list<array{id: int, url: string, body: string, publishedAt: string|null, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, comments: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string}}>
      */
     public function posts(User $user, ?Space $space = null): array
     {
@@ -130,6 +130,7 @@ final class CommunityFeed
         return array_values($posts
             ->map(fn (Post $post): array => [
                 'id' => $post->id,
+                'url' => route('posts.show', $post),
                 'body' => $post->body,
                 'publishedAt' => $post->published_at?->toIso8601String(),
                 'canComment' => in_array($post->space_id, $memberSpaceIds, true),

--- a/app/Community/PostConversation.php
+++ b/app/Community/PostConversation.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Community;
+
+use App\Enums\UserRelationshipType;
+use App\Models\Comment;
+use App\Models\CommentReport;
+use App\Models\Post;
+use App\Models\PostReport;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+final class PostConversation
+{
+    private const COMMENTS_PER_PAGE = 20;
+
+    /**
+     * Build the policy-filtered permalink projection for one post.
+     *
+     * @return array{
+     *     post: array{id: int, url: string, body: string, publishedAt: string|null, isDraft: bool, isHidden: bool, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string, description: string|null, visibility: string, memberCount: int}},
+     *     comments: array{data: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, meta: array{currentPage: int, lastPage: int, perPage: int, total: int}, links: array{newer: string|null, older: string|null}}
+     * }
+     */
+    public function for(User $viewer, Post $post): array
+    {
+        $post->loadMissing([
+            'author:id,name,handle',
+            'space:id,name,slug,description,visibility',
+        ]);
+        $post->space->loadCount('members');
+
+        $hiddenActorIds = DB::table('user_relationships')
+            ->select('target_id')
+            ->where('actor_id', $viewer->getKey())
+            ->whereIn('type', [
+                UserRelationshipType::Mute->value,
+                UserRelationshipType::Block->value,
+            ]);
+        $blockingActorIds = DB::table('user_relationships')
+            ->select('actor_id')
+            ->where('target_id', $viewer->getKey())
+            ->where('type', UserRelationshipType::Block);
+
+        $comments = Comment::query()
+            ->whereBelongsTo($post)
+            ->whereNotNull('published_at')
+            ->whereNull('hidden_at')
+            ->whereNotIn('user_id', clone $hiddenActorIds)
+            ->whereNotIn('user_id', clone $blockingActorIds)
+            ->with('author:id,name,handle')
+            ->latest('published_at')
+            ->latest('id')
+            ->paginate(self::COMMENTS_PER_PAGE)
+            ->withQueryString();
+
+        $commentModels = $comments->getCollection();
+        $visibleAuthorIds = User::query()
+            ->visibleTo($viewer)
+            ->whereKey($commentModels->pluck('user_id')->push($post->user_id)->unique())
+            ->pluck('id')
+            ->all();
+        $reportedCommentIds = CommentReport::query()
+            ->where('reporter_id', $viewer->getKey())
+            ->whereIn('comment_id', $commentModels->pluck('id')->all())
+            ->pluck('comment_id')
+            ->all();
+
+        $commentData = [];
+
+        foreach ($commentModels->reverse() as $comment) {
+            $comment->setRelation('post', $post);
+            $commentData[] = [
+                'id' => $comment->id,
+                'body' => $comment->body,
+                'publishedAt' => $comment->published_at->toIso8601String(),
+                'canReport' => $viewer->can('report', $comment),
+                'hasReported' => in_array($comment->id, $reportedCommentIds, true),
+                'author' => [
+                    'name' => $comment->author->name,
+                    'handle' => $comment->author->handle,
+                    'profileVisible' => in_array($comment->user_id, $visibleAuthorIds, true),
+                ],
+            ];
+        }
+
+        return [
+            'post' => [
+                'id' => $post->id,
+                'url' => route('posts.show', $post),
+                'body' => $post->body,
+                'publishedAt' => $post->published_at?->toIso8601String(),
+                'isDraft' => $post->published_at === null,
+                'isHidden' => $post->hidden_at !== null,
+                'canComment' => $viewer->can('comment', $post),
+                'canReport' => $viewer->can('report', $post),
+                'hasReported' => PostReport::query()
+                    ->where('post_id', $post->getKey())
+                    ->where('reporter_id', $viewer->getKey())
+                    ->exists(),
+                'commentsCount' => $comments->total(),
+                'author' => [
+                    'name' => $post->author->name,
+                    'handle' => $post->author->handle,
+                    'profileVisible' => in_array($post->user_id, $visibleAuthorIds, true),
+                ],
+                'space' => [
+                    'name' => $post->space->name,
+                    'slug' => $post->space->slug,
+                    'description' => $post->space->description,
+                    'visibility' => $post->space->visibility->value,
+                    'memberCount' => $post->space->members_count,
+                ],
+            ],
+            'comments' => [
+                'data' => $commentData,
+                'meta' => [
+                    'currentPage' => $comments->currentPage(),
+                    'lastPage' => $comments->lastPage(),
+                    'perPage' => $comments->perPage(),
+                    'total' => $comments->total(),
+                ],
+                'links' => [
+                    'newer' => $comments->previousPageUrl(),
+                    'older' => $comments->nextPageUrl(),
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,13 +2,34 @@
 
 namespace App\Http\Controllers;
 
+use App\Community\PostConversation;
+use App\Enums\ReportReason;
 use App\Events\PostPublished;
 use App\Http\Requests\StorePostRequest;
+use App\Models\Post;
 use App\Models\Space;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
 
 class PostController extends Controller
 {
+    public function show(Request $request, Post $post, PostConversation $conversation): Response
+    {
+        Gate::authorize('view', $post);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        return Inertia::render('posts/show', [
+            ...$conversation->for($user, $post),
+            'reportReasons' => ReportReason::options(),
+        ]);
+    }
+
     public function store(StorePostRequest $request, Space $space): RedirectResponse
     {
         $post = $space->posts()->create([

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -9,6 +9,12 @@ class PostPolicy
 {
     public function view(User $user, Post $post): bool
     {
+        if ($post->published_at === null
+            && $post->user_id !== $user->getKey()
+            && ! $user->can('moderate', $post->space)) {
+            return false;
+        }
+
         if ($post->hidden_at !== null
             && $post->user_id !== $user->getKey()
             && ! $user->can('moderate', $post->space)) {

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -26,12 +26,17 @@ The current manifest is a deploy-time declaration prototype. Its permission and 
 
 React pages consume server-produced view models rather than raw database models. New layouts should reuse those contracts or introduce versioned projections instead of querying around policies. Design tokens provide a controlled visual baseline; future themes should override semantic tokens and registered presentation components, not copy the application shell.
 
+The web post permalink now consumes a dedicated server-side conversation
+projection. It preserves Space visibility, publication, moderation, mute, block,
+profile-visibility, and report-state boundaries while exposing comments in
+chronological 20-item pages. Feed previews link into this canonical view instead
+of attempting to load an unbounded thread inline.
+
 ## Near-term contract work
 
-1. Add stable, paginated conversation projections for web, mobile, and extension clients.
-2. Add notification events and delivery preferences without coupling them to one UI.
-3. Define media ownership, processing, privacy, and deletion before adding upload controls.
-4. Add versioned API resources for native and decoupled clients.
-5. Implement and test the extension lifecycle before calling the manifest a plugin system.
+1. Add notification events and delivery preferences without coupling them to one UI.
+2. Define media ownership, processing, privacy, and deletion before adding upload controls.
+3. Add versioned API resources for native and decoupled clients, building on the stable web conversation projection.
+4. Implement and test the extension lifecycle before calling the manifest a plugin system.
 
 The goal is composability with secure defaults, not unlimited runtime code execution.

--- a/resources/js/components/social/comment-thread.tsx
+++ b/resources/js/components/social/comment-thread.tsx
@@ -1,5 +1,5 @@
 import { Link, useForm } from '@inertiajs/react';
-import { Flag, MessageCircle, Send } from 'lucide-react';
+import { ArrowRight, Flag, MessageCircle, Send } from 'lucide-react';
 import { useState } from 'react';
 import type { FormEvent } from 'react';
 import InputError from '@/components/input-error';
@@ -15,13 +15,14 @@ export type SocialComment = {
     author: { name: string; handle: string; profileVisible: boolean };
 };
 
-type ReportReason = {
+export type ReportReason = {
     value: string;
     label: string;
 };
 
 type CommentThreadProps = {
     postId: number;
+    postUrl: string;
     comments: SocialComment[];
     commentsCount: number;
     canComment: boolean;
@@ -123,7 +124,7 @@ function CommentReport({
     );
 }
 
-function CommentRow({
+export function CommentRow({
     comment,
     reportReasons,
 }: {
@@ -192,7 +193,7 @@ function CommentRow({
     );
 }
 
-function CommentComposer({ postId }: { postId: number }) {
+export function CommentComposer({ postId }: { postId: number }) {
     const { data, setData, post, processing, errors, reset } = useForm({
         body: '',
     });
@@ -240,6 +241,7 @@ function CommentComposer({ postId }: { postId: number }) {
 
 export function CommentThread({
     postId,
+    postUrl,
     comments,
     commentsCount,
     canComment,
@@ -263,9 +265,13 @@ export function CommentThread({
                         : `${commentsCount.toLocaleString()} ${commentsCount === 1 ? 'comment' : 'comments'}`}
                 </button>
                 {commentsCount > comments.length && (
-                    <span className="text-xs font-semibold text-muted-foreground">
-                        Latest {comments.length}
-                    </span>
+                    <Link
+                        href={`${postUrl}#conversation`}
+                        className="social-focus inline-flex min-h-10 items-center gap-1.5 rounded-xl px-2.5 text-xs font-extrabold text-primary transition-colors hover:bg-primary/8"
+                    >
+                        View all
+                        <ArrowRight className="size-3.5" aria-hidden="true" />
+                    </Link>
                 )}
             </div>
 

--- a/resources/js/pages/feed/index.tsx
+++ b/resources/js/pages/feed/index.tsx
@@ -32,6 +32,7 @@ type Space = {
 
 type FeedPost = {
     id: number;
+    url: string;
     body: string;
     publishedAt: string | null;
     canComment: boolean;
@@ -278,12 +279,14 @@ function PostCard({
                             {item.space.name}
                         </Link>
                     </div>
-                    <time
-                        dateTime={item.publishedAt ?? undefined}
-                        className="text-xs font-medium text-muted-foreground"
+                    <Link
+                        href={item.url}
+                        className="social-focus inline-flex rounded-md text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
                     >
-                        {publishedLabel(item.publishedAt)}
-                    </time>
+                        <time dateTime={item.publishedAt ?? undefined}>
+                            {publishedLabel(item.publishedAt)}
+                        </time>
+                    </Link>
                 </div>
                 {item.hasReported ? (
                     <span className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-xl bg-secondary px-3 text-xs font-bold text-muted-foreground">
@@ -384,6 +387,7 @@ function PostCard({
             )}
             <CommentThread
                 postId={item.id}
+                postUrl={item.url}
                 comments={item.comments}
                 commentsCount={item.commentsCount}
                 canComment={item.canComment}

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,0 +1,514 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+import {
+    ArrowLeft,
+    ChevronLeft,
+    ChevronRight,
+    Flag,
+    Globe2,
+    LockKeyhole,
+    MessageCircle,
+} from 'lucide-react';
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import InputError from '@/components/input-error';
+import { AvatarMark } from '@/components/social/avatar-mark';
+import {
+    CommentComposer,
+    CommentRow,
+} from '@/components/social/comment-thread';
+import type {
+    ReportReason,
+    SocialComment,
+} from '@/components/social/comment-thread';
+import { CommunitySignal } from '@/components/social/community-signal';
+import { SpaceCover } from '@/components/social/space-cover';
+import { Button } from '@/components/ui/button';
+
+type ConversationPost = {
+    id: number;
+    url: string;
+    body: string;
+    publishedAt: string | null;
+    isDraft: boolean;
+    isHidden: boolean;
+    canComment: boolean;
+    canReport: boolean;
+    hasReported: boolean;
+    commentsCount: number;
+    author: { name: string; handle: string; profileVisible: boolean };
+    space: {
+        name: string;
+        slug: string;
+        description: string | null;
+        visibility: 'public' | 'private' | 'hidden';
+        memberCount: number;
+    };
+};
+
+type ConversationPage = {
+    data: SocialComment[];
+    meta: {
+        currentPage: number;
+        lastPage: number;
+        perPage: number;
+        total: number;
+    };
+    links: {
+        newer: string | null;
+        older: string | null;
+    };
+};
+
+type ShowPostProps = {
+    post: ConversationPost;
+    comments: ConversationPage;
+    reportReasons: ReportReason[];
+    status?: string;
+};
+
+const publishedLabel = (value: string | null) => {
+    if (!value) {
+        return 'Draft';
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(value));
+};
+
+const anchored = (url: string) => `${url}#conversation`;
+
+export default function ShowPost({
+    post,
+    comments,
+    reportReasons,
+    status,
+}: ShowPostProps) {
+    const [reporting, setReporting] = useState(false);
+    const {
+        data,
+        setData,
+        post: submit,
+        processing,
+        errors,
+        reset,
+    } = useForm({
+        reason: '',
+        details: '',
+    });
+
+    const submitReport = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        submit(`/posts/${post.id}/reports`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                reset();
+                setReporting(false);
+            },
+        });
+    };
+
+    const isLatestPage = comments.meta.currentPage === 1;
+    const spaceUrl = `/spaces/${encodeURIComponent(post.space.slug)}`;
+
+    return (
+        <>
+            <Head title={`Conversation in ${post.space.name}`} />
+            <main className="social-page max-w-[82rem]">
+                <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,46rem)_19rem] xl:justify-center">
+                    <div className="min-w-0">
+                        <header className="mb-4 px-1 sm:mb-5">
+                            <Link
+                                href={spaceUrl}
+                                className="social-focus inline-flex min-h-10 items-center gap-2 rounded-xl pr-3 text-sm font-extrabold text-primary transition-colors hover:bg-primary/8"
+                            >
+                                <ArrowLeft
+                                    className="size-4"
+                                    aria-hidden="true"
+                                />
+                                {post.space.name}
+                            </Link>
+                            <div className="mt-2 flex flex-wrap items-end justify-between gap-3">
+                                <div>
+                                    <div className="social-eyebrow">
+                                        <CommunitySignal />
+                                        Post permalink
+                                    </div>
+                                    <h1 className="mt-1 text-2xl font-black tracking-[-0.035em] sm:text-[2rem]">
+                                        Conversation
+                                    </h1>
+                                </div>
+                                <span className="inline-flex min-h-9 items-center rounded-full bg-secondary px-3 text-xs font-extrabold text-muted-foreground">
+                                    {post.commentsCount.toLocaleString()}{' '}
+                                    {post.commentsCount === 1
+                                        ? 'comment'
+                                        : 'comments'}
+                                </span>
+                            </div>
+                        </header>
+
+                        {status && (
+                            <div
+                                role="status"
+                                className="mb-4 rounded-2xl border border-primary/20 bg-primary/8 px-4 py-3 text-sm font-bold"
+                            >
+                                {status}
+                            </div>
+                        )}
+
+                        <article className="social-card overflow-hidden rounded-[1.35rem]">
+                            {(post.isDraft || post.isHidden) && (
+                                <div className="border-b border-coral/20 bg-coral/10 px-4 py-3 text-sm font-bold sm:px-5">
+                                    {post.isDraft
+                                        ? 'This draft is visible only to its author and Space moderators.'
+                                        : 'This post is hidden from community feeds.'}
+                                </div>
+                            )}
+                            <div className="p-4 sm:p-5">
+                                <header className="flex items-start gap-3">
+                                    <AvatarMark
+                                        name={post.author.name}
+                                        className="size-11"
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                        {post.author.profileVisible ? (
+                                            <Link
+                                                href={`/people/${post.author.handle}`}
+                                                className="social-focus inline-flex rounded-md font-extrabold tracking-tight hover:underline"
+                                            >
+                                                {post.author.name}
+                                            </Link>
+                                        ) : (
+                                            <span className="font-extrabold tracking-tight">
+                                                {post.author.name}
+                                            </span>
+                                        )}
+                                        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-xs font-medium text-muted-foreground">
+                                            <time
+                                                dateTime={
+                                                    post.publishedAt ??
+                                                    undefined
+                                                }
+                                            >
+                                                {publishedLabel(
+                                                    post.publishedAt,
+                                                )}
+                                            </time>
+                                            <span aria-hidden="true">·</span>
+                                            <Link
+                                                href={spaceUrl}
+                                                className="font-bold text-primary hover:underline"
+                                            >
+                                                {post.space.name}
+                                            </Link>
+                                        </div>
+                                    </div>
+                                    {post.hasReported ? (
+                                        <span className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-xl bg-secondary px-3 text-xs font-bold text-muted-foreground">
+                                            <Flag
+                                                className="size-3.5"
+                                                aria-hidden="true"
+                                            />
+                                            Reported
+                                        </span>
+                                    ) : (
+                                        post.canReport && (
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    setReporting(
+                                                        (open) => !open,
+                                                    )
+                                                }
+                                                aria-expanded={reporting}
+                                                className="social-focus inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-xl px-3 text-xs font-bold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                                            >
+                                                <Flag
+                                                    className="size-3.5"
+                                                    aria-hidden="true"
+                                                />
+                                                Report
+                                            </button>
+                                        )
+                                    )}
+                                </header>
+
+                                <p className="mt-5 text-[1.04rem] leading-8 whitespace-pre-wrap text-foreground/92">
+                                    {post.body}
+                                </p>
+
+                                {reporting && (
+                                    <form
+                                        onSubmit={submitReport}
+                                        className="mt-5 border-t pt-4"
+                                        aria-label="Report this post"
+                                    >
+                                        <label className="block text-sm font-bold">
+                                            What is the concern?
+                                            <select
+                                                value={data.reason}
+                                                onChange={(event) =>
+                                                    setData(
+                                                        'reason',
+                                                        event.target.value,
+                                                    )
+                                                }
+                                                required
+                                                className="social-inset social-focus mt-2 h-11 w-full px-3 text-sm font-semibold"
+                                            >
+                                                <option value="">
+                                                    Choose a reason
+                                                </option>
+                                                {reportReasons.map((reason) => (
+                                                    <option
+                                                        key={reason.value}
+                                                        value={reason.value}
+                                                    >
+                                                        {reason.label}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                        </label>
+                                        <InputError
+                                            className="mt-2"
+                                            message={errors.reason}
+                                        />
+                                        <label className="mt-3 block text-sm font-bold">
+                                            Details{' '}
+                                            <span className="font-medium text-muted-foreground">
+                                                {data.reason === 'other'
+                                                    ? '(required)'
+                                                    : '(optional)'}
+                                            </span>
+                                            <textarea
+                                                value={data.details}
+                                                onChange={(event) =>
+                                                    setData(
+                                                        'details',
+                                                        event.target.value,
+                                                    )
+                                                }
+                                                required={
+                                                    data.reason === 'other'
+                                                }
+                                                maxLength={750}
+                                                rows={3}
+                                                className="social-inset social-focus mt-2 w-full resize-y px-3.5 py-3 text-sm leading-6"
+                                            />
+                                        </label>
+                                        <InputError
+                                            className="mt-2"
+                                            message={errors.details}
+                                        />
+                                        <div className="mt-3 flex justify-end gap-2">
+                                            <Button
+                                                type="button"
+                                                variant="outline"
+                                                onClick={() => {
+                                                    reset();
+                                                    setReporting(false);
+                                                }}
+                                            >
+                                                Cancel
+                                            </Button>
+                                            <Button
+                                                type="submit"
+                                                disabled={
+                                                    processing ||
+                                                    data.reason === ''
+                                                }
+                                            >
+                                                <Flag
+                                                    className="size-4"
+                                                    aria-hidden="true"
+                                                />
+                                                Send report
+                                            </Button>
+                                        </div>
+                                    </form>
+                                )}
+                            </div>
+                        </article>
+
+                        <section
+                            id="conversation"
+                            className="social-card mt-4 scroll-mt-20 rounded-[1.35rem] p-4 sm:mt-5 sm:p-5"
+                            aria-labelledby="conversation-title"
+                        >
+                            <div className="flex flex-wrap items-end justify-between gap-3 border-b pb-4">
+                                <div>
+                                    <p className="social-eyebrow">
+                                        Chronological
+                                    </p>
+                                    <h2
+                                        id="conversation-title"
+                                        className="mt-1 text-xl font-black tracking-[-0.025em]"
+                                    >
+                                        Full conversation
+                                    </h2>
+                                </div>
+                                {comments.meta.lastPage > 1 && (
+                                    <span className="text-xs font-bold text-muted-foreground">
+                                        Page {comments.meta.currentPage} of{' '}
+                                        {comments.meta.lastPage}
+                                    </span>
+                                )}
+                            </div>
+
+                            {comments.data.length === 0 ? (
+                                <div className="py-10 text-center">
+                                    <div className="mx-auto flex size-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                                        <MessageCircle
+                                            className="size-5"
+                                            aria-hidden="true"
+                                        />
+                                    </div>
+                                    <h3 className="mt-3 font-extrabold">
+                                        Start the conversation.
+                                    </h3>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                        Be the first member to add a thoughtful
+                                        reply.
+                                    </p>
+                                </div>
+                            ) : (
+                                <div className="mt-4 space-y-3">
+                                    {comments.data.map((comment) => (
+                                        <CommentRow
+                                            key={comment.id}
+                                            comment={comment}
+                                            reportReasons={reportReasons}
+                                        />
+                                    ))}
+                                </div>
+                            )}
+
+                            {comments.meta.lastPage > 1 && (
+                                <nav
+                                    className="mt-5 flex items-center justify-between gap-3 border-t pt-4"
+                                    aria-label="Conversation pages"
+                                >
+                                    {comments.links.newer ? (
+                                        <Link
+                                            href={anchored(
+                                                comments.links.newer,
+                                            )}
+                                            className="social-focus inline-flex min-h-11 items-center gap-2 rounded-xl border border-border/80 px-3.5 text-sm font-extrabold transition-colors hover:border-primary/20 hover:bg-secondary"
+                                        >
+                                            <ChevronLeft
+                                                className="size-4"
+                                                aria-hidden="true"
+                                            />
+                                            Newer
+                                        </Link>
+                                    ) : (
+                                        <span />
+                                    )}
+                                    {comments.links.older && (
+                                        <Link
+                                            href={anchored(
+                                                comments.links.older,
+                                            )}
+                                            className="social-focus inline-flex min-h-11 items-center gap-2 rounded-xl border border-border/80 px-3.5 text-sm font-extrabold transition-colors hover:border-primary/20 hover:bg-secondary"
+                                        >
+                                            Older
+                                            <ChevronRight
+                                                className="size-4"
+                                                aria-hidden="true"
+                                            />
+                                        </Link>
+                                    )}
+                                </nav>
+                            )}
+
+                            {post.canComment && isLatestPage ? (
+                                <div className="mt-5 border-t pt-2">
+                                    <CommentComposer postId={post.id} />
+                                </div>
+                            ) : post.canComment ? (
+                                <Link
+                                    href={`${post.url}#conversation`}
+                                    className="social-focus mt-5 flex min-h-11 items-center justify-center rounded-xl bg-primary px-4 text-sm font-extrabold text-primary-foreground transition-opacity hover:opacity-92"
+                                >
+                                    Return to the latest comments to reply
+                                </Link>
+                            ) : (
+                                <p className="mt-5 rounded-xl bg-secondary/45 px-3 py-2.5 text-xs font-semibold text-muted-foreground">
+                                    Join this Space to take part in the
+                                    conversation.
+                                </p>
+                            )}
+                        </section>
+                    </div>
+
+                    <aside
+                        className="hidden space-y-4 xl:sticky xl:top-6 xl:block xl:self-start"
+                        aria-label="Space context"
+                    >
+                        <Link
+                            href={spaceUrl}
+                            className="social-card social-card-interactive social-focus group block overflow-hidden rounded-[1.35rem]"
+                        >
+                            <div className="relative h-32 overflow-hidden bg-secondary">
+                                <SpaceCover
+                                    seed={post.space.slug}
+                                    className="absolute inset-0 transition-transform duration-300 group-hover:scale-[1.025]"
+                                />
+                            </div>
+                            <div className="p-4">
+                                <div className="flex items-center gap-2 text-[0.68rem] font-extrabold tracking-[0.12em] text-primary uppercase">
+                                    {post.space.visibility === 'public' ? (
+                                        <Globe2
+                                            className="size-3.5"
+                                            aria-hidden="true"
+                                        />
+                                    ) : (
+                                        <LockKeyhole
+                                            className="size-3.5"
+                                            aria-hidden="true"
+                                        />
+                                    )}
+                                    {post.space.visibility} Space
+                                </div>
+                                <h2 className="mt-2 text-lg font-black tracking-[-0.02em]">
+                                    {post.space.name}
+                                </h2>
+                                {post.space.description && (
+                                    <p className="mt-2 line-clamp-3 text-sm leading-6 text-muted-foreground">
+                                        {post.space.description}
+                                    </p>
+                                )}
+                                <p className="mt-3 text-xs font-bold text-muted-foreground">
+                                    {post.space.memberCount.toLocaleString()}{' '}
+                                    {post.space.memberCount === 1
+                                        ? 'member'
+                                        : 'members'}
+                                </p>
+                            </div>
+                        </Link>
+
+                        <div className="social-card rounded-[1.35rem] p-5">
+                            <CommunitySignal className="text-primary" />
+                            <p className="mt-4 text-sm font-black tracking-[-0.01em]">
+                                Conversations stay chronological.
+                            </p>
+                            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                                No ranking, popularity score, or hidden
+                                engagement model decides which replies you can
+                                reach.
+                            </p>
+                        </div>
+                    </aside>
+                </div>
+            </main>
+        </>
+    );
+}
+
+ShowPost.layout = {
+    breadcrumbs: [
+        { title: 'Feed', href: '/feed' },
+        { title: 'Conversation', href: '#' },
+    ],
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('spaces/{space:slug}/posts', [PostController::class, 'store'])
         ->middleware('throttle:post-publishing')
         ->name('spaces.posts.store');
+    Route::get('posts/{post}', [PostController::class, 'show'])
+        ->name('posts.show');
     Route::post('posts/{post}/reports', [PostReportController::class, 'store'])
         ->middleware('throttle:post-reporting')
         ->name('posts.reports.store');

--- a/tests/Feature/CommentConversationTest.php
+++ b/tests/Feature/CommentConversationTest.php
@@ -109,6 +109,121 @@ class CommentConversationTest extends TestCase
                 ->where('posts.0.comments.1.body', 'Second visible reply'));
     }
 
+    public function test_post_permalink_enforces_account_space_publication_and_block_boundaries(): void
+    {
+        $viewer = User::factory()->create();
+        $unverified = User::factory()->unverified()->create();
+        $author = User::factory()->create();
+        $publicSpace = Space::factory()->create();
+        $privateSpace = Space::factory()->private()->create();
+        $publishedPost = Post::factory()->for($publicSpace)->for($author, 'author')->create();
+        $privatePost = Post::factory()->for($privateSpace)->for($author, 'author')->create();
+        $draftPost = Post::factory()->for($publicSpace)->for($author, 'author')->create([
+            'published_at' => null,
+        ]);
+
+        $this->get(route('posts.show', $publishedPost))
+            ->assertRedirect(route('login'));
+
+        $this->actingAs($unverified)
+            ->get(route('posts.show', $publishedPost))
+            ->assertRedirect(route('verification.notice'));
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', $publishedPost))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('posts/show')
+                ->where('post.id', $publishedPost->getKey())
+                ->where('post.url', route('posts.show', $publishedPost)));
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', $privatePost))
+            ->assertForbidden();
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', $draftPost))
+            ->assertForbidden();
+
+        $this->actingAs($author)
+            ->get(route('posts.show', $draftPost))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page->where('post.isDraft', true));
+
+        $author->outgoingRelationships()->create([
+            'target_id' => $viewer->getKey(),
+            'type' => 'block',
+        ]);
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', $publishedPost))
+            ->assertForbidden();
+    }
+
+    public function test_post_permalink_paginates_the_full_visible_conversation_in_chronological_chunks(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create(['profile_visibility' => 'public']);
+        $mutedAuthor = User::factory()->create();
+        $blockingAuthor = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($viewer);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+
+        foreach (range(1, 23) as $index) {
+            Comment::factory()->for($post)->for($author, 'author')->create([
+                'body' => sprintf('Visible %02d', $index),
+                'published_at' => now()->subMinutes(24 - $index),
+            ]);
+        }
+
+        Comment::factory()->for($post)->for($mutedAuthor, 'author')->create([
+            'body' => 'Muted reply',
+        ]);
+        Comment::factory()->for($post)->for($blockingAuthor, 'author')->create([
+            'body' => 'Blocking reply',
+        ]);
+        Comment::factory()->for($post)->for($author, 'author')->create([
+            'body' => 'Hidden reply',
+            'hidden_at' => now(),
+        ]);
+        $viewer->outgoingRelationships()->create([
+            'target_id' => $mutedAuthor->getKey(),
+            'type' => 'mute',
+        ]);
+        $blockingAuthor->outgoingRelationships()->create([
+            'target_id' => $viewer->getKey(),
+            'type' => 'block',
+        ]);
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('post.commentsCount', 23)
+                ->where('post.canComment', true)
+                ->has('comments.data', 20)
+                ->where('comments.data.0.body', 'Visible 04')
+                ->where('comments.data.19.body', 'Visible 23')
+                ->where('comments.meta.currentPage', 1)
+                ->where('comments.meta.lastPage', 2)
+                ->where('comments.meta.perPage', 20)
+                ->where('comments.meta.total', 23)
+                ->where('comments.links.newer', null)
+                ->where('comments.links.older', fn ($url) => is_string($url) && str_contains($url, 'page=2')));
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', ['post' => $post, 'page' => 2]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('comments.data', 3)
+                ->where('comments.data.0.body', 'Visible 01')
+                ->where('comments.data.2.body', 'Visible 03')
+                ->where('comments.meta.currentPage', 2)
+                ->where('comments.links.older', null)
+                ->where('comments.links.newer', fn ($url) => is_string($url) && str_contains($url, 'page=1')));
+    }
+
     public function test_visible_comment_can_be_reported_once_but_not_by_its_author(): void
     {
         Event::fake([CommentReported::class]);


### PR DESCRIPTION
Posts now have a stable place for members to read and continue a full conversation without turning the feed into an unbounded thread.

This adds a responsive post permalink, chronological 20-comment pages, Older/Newer navigation, and feed links into the canonical conversation. The server projection keeps Space visibility, publication, moderation, mute, block, profile visibility, and report state enforced before data reaches React.

Validated with:
- `composer run test` — 94 tests, 707 assertions
- `npm run lint:check`
- `npm run format:check`
- `npm run types:check`
- `npm run build`
- Browser checks at 1440×900 and 390×844, including both pagination directions, no horizontal overflow, and no console warnings