### PR TITLE
Add a low-noise in-app notification center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable project changes will be documented here.
 
 - Permanent post links with a responsive full-conversation view, chronological
   20-comment pages, and policy-filtered access to older replies.
+- Database-backed in-app notifications for replies and new Space moderation
+  reports, with unread state, secure destinations, and paginated history.
+- Per-member preferences for reply and moderation notification categories.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
   links, and a full visibility-filtered paginated conversation view.
 - Private post and comment reporting with allowlisted reasons, duplicate protection, and separate rate limits.
 - A unified, policy-backed moderator queue with documented decisions, content hide/restore behavior, and append-only Space audit entries.
+- A low-noise in-app notification center for replies and new moderation reports,
+  with per-category preferences, unread state, and access rechecked when opened.
 - Stable member handles, editable profiles with headlines, real visible
   activity summaries, and privacy-aware People discovery.
 - Public, shared-Space-only, and private profile visibility with discovery opt-out.
@@ -51,7 +53,9 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
 - A local extension-manifest contract with explicit permission and UI-slot allowlists.
 - React 19, Inertia 3, TypeScript, Tailwind CSS 4, and Laravel 13.
 
-This is an early development build, not a production release. Messaging, media, notifications, full content search, data export/deletion, and a supported extension lifecycle are still pending.
+This is an early development build, not a production release. Messaging, media,
+email and push notification delivery, full content search, data export/deletion,
+and a supported extension lifecycle are still pending.
 
 ## Local setup
 
@@ -87,6 +91,10 @@ The current manifest prototype discovers extensions only from configured local d
 See [`extensions/example-polls/extension.json`](extensions/example-polls/extension.json) for the first contract example.
 
 Moderation integrations can listen to after-transaction domain events. See [`docs/moderation.md`](docs/moderation.md) for the lifecycle, authorization boundaries, and guidance for adding new reportable content types.
+
+The first notification contract deliberately stores identifiers rather than
+content excerpts or report details. See [`docs/notifications.md`](docs/notifications.md)
+for delivery categories, privacy boundaries, and extension guidance.
 
 The core owns identity, Spaces, visibility, safety relationships, conversations, and moderation. Product-specific experiences—photo grids, short-video feeds, professional timelines, events, commerce, or learning—should build on those boundaries through presentation layers and extensions rather than weakening core policies. See [`docs/platform-architecture.md`](docs/platform-architecture.md) for the current separation and the contracts that still need to mature.
 

--- a/app/Community/NotificationCenter.php
+++ b/app/Community/NotificationCenter.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Community;
+
+use App\Enums\NotificationType;
+use App\Models\Comment;
+use App\Models\CommentReport;
+use App\Models\PostReport;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Gate;
+
+final class NotificationCenter
+{
+    private const PER_PAGE = 20;
+
+    public function __construct(private readonly PostConversation $conversations) {}
+
+    /**
+     * @return array{
+     *     items: list<array{id: string, kind: string, title: string, description: string, createdAt: string, readAt: string|null, available: bool}>,
+     *     meta: array{currentPage: int, lastPage: int, perPage: int, total: int},
+     *     links: array{previous: string|null, next: string|null}
+     * }
+     */
+    public function for(User $viewer, string $filter): array
+    {
+        $notifications = DatabaseNotification::query()
+            ->where('notifiable_type', $viewer->getMorphClass())
+            ->where('notifiable_id', $viewer->getKey())
+            ->when($filter === 'unread', fn ($query) => $query->whereNull('read_at'))
+            ->latest()
+            ->paginate(self::PER_PAGE)
+            ->withQueryString();
+        $items = [];
+
+        foreach ($notifications->items() as $notification) {
+            $resolved = $this->resolve($viewer, $notification);
+            $items[] = [
+                'id' => $notification->id,
+                'kind' => $resolved['kind'],
+                'title' => $resolved['title'],
+                'description' => $resolved['description'],
+                'createdAt' => $notification->created_at->toIso8601String(),
+                'readAt' => $notification->read_at?->toIso8601String(),
+                'available' => $resolved['destination'] !== null,
+            ];
+        }
+
+        return [
+            'items' => $items,
+            'meta' => [
+                'currentPage' => $notifications->currentPage(),
+                'lastPage' => $notifications->lastPage(),
+                'perPage' => $notifications->perPage(),
+                'total' => $notifications->total(),
+            ],
+            'links' => [
+                'previous' => $notifications->previousPageUrl(),
+                'next' => $notifications->nextPageUrl(),
+            ],
+        ];
+    }
+
+    public function findFor(User $viewer, string $id): DatabaseNotification
+    {
+        return DatabaseNotification::query()
+            ->where('notifiable_type', $viewer->getMorphClass())
+            ->where('notifiable_id', $viewer->getKey())
+            ->findOrFail($id);
+    }
+
+    public function destination(User $viewer, DatabaseNotification $notification): ?string
+    {
+        return $this->resolve($viewer, $notification)['destination'];
+    }
+
+    /** @return array{kind: string, title: string, description: string, destination: string|null} */
+    private function resolve(User $viewer, DatabaseNotification $notification): array
+    {
+        return match (NotificationType::tryFrom($notification->type)) {
+            NotificationType::CommentReply => $this->resolveCommentReply($viewer, $notification),
+            NotificationType::SpaceModeration => $this->resolveSpaceModeration($viewer, $notification),
+            default => $this->unavailable(),
+        };
+    }
+
+    /** @return array{kind: string, title: string, description: string, destination: string|null} */
+    private function resolveCommentReply(User $viewer, DatabaseNotification $notification): array
+    {
+        $commentId = $this->integer($notification, 'comment_id');
+
+        if ($commentId === null) {
+            return $this->unavailable();
+        }
+
+        $comment = Comment::query()
+            ->with(['author', 'post.author', 'post.space'])
+            ->find($commentId);
+
+        if (! $comment instanceof Comment
+            || Gate::forUser($viewer)->denies('view', $comment)) {
+            return $this->unavailable();
+        }
+
+        $destination = $this->conversations->urlForComment($viewer, $comment);
+
+        if ($destination === null) {
+            return $this->unavailable();
+        }
+
+        $actorVisible = User::query()
+            ->visibleTo($viewer)
+            ->whereKey($comment->user_id)
+            ->exists();
+
+        return [
+            'kind' => NotificationType::CommentReply->value,
+            'title' => $actorVisible
+                ? $comment->author->name.' replied to your post'
+                : 'A member replied to your post',
+            'description' => 'Open the conversation in '.$comment->post->space->name.'.',
+            'destination' => $destination,
+        ];
+    }
+
+    /** @return array{kind: string, title: string, description: string, destination: string|null} */
+    private function resolveSpaceModeration(User $viewer, DatabaseNotification $notification): array
+    {
+        $spaceId = $this->integer($notification, 'space_id');
+        $reportId = $this->integer($notification, 'report_id');
+        $reportKind = $notification->data['report_kind'] ?? null;
+
+        if ($spaceId === null || $reportId === null || ! in_array($reportKind, ['post', 'comment'], true)) {
+            return $this->unavailable();
+        }
+
+        $space = Space::query()->find($spaceId);
+
+        if (! $space instanceof Space
+            || Gate::forUser($viewer)->denies('moderate', $space)) {
+            return $this->unavailable();
+        }
+
+        $reportExists = $reportKind === 'post'
+            ? PostReport::query()->whereKey($reportId)->whereBelongsTo($space)->exists()
+            : CommentReport::query()->whereKey($reportId)->whereBelongsTo($space)->exists();
+
+        if (! $reportExists) {
+            return $this->unavailable();
+        }
+
+        return [
+            'kind' => NotificationType::SpaceModeration->value,
+            'title' => 'New '.$reportKind.' report',
+            'description' => 'Review the moderation queue in '.$space->name.'.',
+            'destination' => route('spaces.moderation.index', $space),
+        ];
+    }
+
+    private function integer(DatabaseNotification $notification, string $key): ?int
+    {
+        $value = $notification->data[$key] ?? null;
+
+        return is_int($value) && $value > 0 ? $value : null;
+    }
+
+    /** @return array{kind: string, title: string, description: string, destination: null} */
+    private function unavailable(): array
+    {
+        return [
+            'kind' => 'unavailable',
+            'title' => 'Notification unavailable',
+            'description' => 'The content was removed or you no longer have access.',
+            'destination' => null,
+        ];
+    }
+}

--- a/app/Community/PostConversation.php
+++ b/app/Community/PostConversation.php
@@ -8,6 +8,7 @@ use App\Models\CommentReport;
 use App\Models\Post;
 use App\Models\PostReport;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
 final class PostConversation
@@ -30,24 +31,7 @@ final class PostConversation
         ]);
         $post->space->loadCount('members');
 
-        $hiddenActorIds = DB::table('user_relationships')
-            ->select('target_id')
-            ->where('actor_id', $viewer->getKey())
-            ->whereIn('type', [
-                UserRelationshipType::Mute->value,
-                UserRelationshipType::Block->value,
-            ]);
-        $blockingActorIds = DB::table('user_relationships')
-            ->select('actor_id')
-            ->where('target_id', $viewer->getKey())
-            ->where('type', UserRelationshipType::Block);
-
-        $comments = Comment::query()
-            ->whereBelongsTo($post)
-            ->whereNotNull('published_at')
-            ->whereNull('hidden_at')
-            ->whereNotIn('user_id', clone $hiddenActorIds)
-            ->whereNotIn('user_id', clone $blockingActorIds)
+        $comments = $this->visibleComments($viewer, $post)
             ->with('author:id,name,handle')
             ->latest('published_at')
             ->latest('id')
@@ -126,5 +110,58 @@ final class PostConversation
                 ],
             ],
         ];
+    }
+
+    public function urlForComment(User $viewer, Comment $comment): ?string
+    {
+        $comment->loadMissing('post');
+        $query = $this->visibleComments($viewer, $comment->post);
+
+        if (! (clone $query)->whereKey($comment->getKey())->exists()) {
+            return null;
+        }
+
+        $newerComments = (clone $query)
+            ->where(function (Builder $newer) use ($comment): void {
+                $newer
+                    ->where('published_at', '>', $comment->published_at)
+                    ->orWhere(function (Builder $sameTime) use ($comment): void {
+                        $sameTime
+                            ->where('published_at', $comment->published_at)
+                            ->where('id', '>', $comment->id);
+                    });
+            })
+            ->count();
+        $page = intdiv($newerComments, self::COMMENTS_PER_PAGE) + 1;
+        $parameters = ['post' => $comment->post];
+
+        if ($page > 1) {
+            $parameters['page'] = $page;
+        }
+
+        return route('posts.show', $parameters).'#comment-'.$comment->id;
+    }
+
+    /** @return Builder<Comment> */
+    private function visibleComments(User $viewer, Post $post): Builder
+    {
+        $hiddenActorIds = DB::table('user_relationships')
+            ->select('target_id')
+            ->where('actor_id', $viewer->getKey())
+            ->whereIn('type', [
+                UserRelationshipType::Mute->value,
+                UserRelationshipType::Block->value,
+            ]);
+        $blockingActorIds = DB::table('user_relationships')
+            ->select('actor_id')
+            ->where('target_id', $viewer->getKey())
+            ->where('type', UserRelationshipType::Block);
+
+        return Comment::query()
+            ->whereBelongsTo($post)
+            ->whereNotNull('published_at')
+            ->whereNull('hidden_at')
+            ->whereNotIn('user_id', $hiddenActorIds)
+            ->whereNotIn('user_id', $blockingActorIds);
     }
 }

--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum NotificationType: string
+{
+    case CommentReply = 'comment_reply';
+    case SpaceModeration = 'space_moderation';
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Community\NotificationCenter;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Notifications\DatabaseNotification;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NotificationController extends Controller
+{
+    public function index(Request $request, NotificationCenter $center): Response
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $filter = $request->query('filter') === 'unread' ? 'unread' : 'all';
+
+        return Inertia::render('notifications/index', [
+            ...$center->for($user, $filter),
+            'filter' => $filter,
+        ]);
+    }
+
+    public function open(Request $request, string $notification, NotificationCenter $center): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $record = $center->findFor($user, $notification);
+        $destination = $center->destination($user, $record);
+        $record->markAsRead();
+
+        if ($destination === null) {
+            return redirect()->route('notifications.index')
+                ->with('status', 'This notification is no longer available.');
+        }
+
+        return redirect()->to($destination);
+    }
+
+    public function read(Request $request, string $notification, NotificationCenter $center): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $center->findFor($user, $notification)->markAsRead();
+
+        return back()->with('status', 'Notification marked as read.');
+    }
+
+    public function readAll(Request $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        DatabaseNotification::query()
+            ->where('notifiable_type', $user->getMorphClass())
+            ->where('notifiable_id', $user->getKey())
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        return back()->with('status', 'All notifications marked as read.');
+    }
+}

--- a/app/Http/Controllers/Settings/NotificationPreferencesController.php
+++ b/app/Http/Controllers/Settings/NotificationPreferencesController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateNotificationPreferencesRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NotificationPreferencesController extends Controller
+{
+    public function edit(Request $request): Response
+    {
+        $preferences = $request->user()->notificationPreference()->firstOrNew();
+
+        return Inertia::render('settings/notifications', [
+            'preferences' => [
+                'commentReplies' => $preferences->exists ? $preferences->comment_replies : true,
+                'spaceModeration' => $preferences->exists ? $preferences->space_moderation : true,
+            ],
+        ]);
+    }
+
+    public function update(UpdateNotificationPreferencesRequest $request): RedirectResponse
+    {
+        $request->user()->notificationPreference()->updateOrCreate(
+            [],
+            $request->validated(),
+        );
+
+        return back()->with('status', 'Notification preferences saved.');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -41,6 +41,9 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
+            'notificationSummary' => fn (): array => [
+                'unreadCount' => $request->user()?->unreadNotifications()->count() ?? 0,
+            ],
             'status' => fn () => $request->session()->get('status'),
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
         ];

--- a/app/Http/Requests/UpdateNotificationPreferencesRequest.php
+++ b/app/Http/Requests/UpdateNotificationPreferencesRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateNotificationPreferencesRequest extends FormRequest
+{
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'comment_replies' => ['required', 'boolean'],
+            'space_moderation' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Listeners/NotifyPostAuthorOfComment.php
+++ b/app/Listeners/NotifyPostAuthorOfComment.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\CommentPublished;
+use App\Models\NotificationPreference;
+use App\Notifications\CommentReplyNotification;
+use Illuminate\Support\Facades\Gate;
+
+class NotifyPostAuthorOfComment
+{
+    public function handle(CommentPublished $event): void
+    {
+        $comment = $event->comment->loadMissing([
+            'author',
+            'post.author',
+            'post.space',
+        ]);
+        $recipient = $comment->post->author;
+
+        if ($recipient->is($comment->author)
+            || $recipient->hasMuted($comment->author)
+            || $recipient->isBlockedWith($comment->author)
+            || Gate::forUser($recipient)->denies('view', $comment->post)) {
+            return;
+        }
+
+        $recipient->loadMissing('notificationPreference');
+
+        if ($recipient->notificationPreference instanceof NotificationPreference
+            && ! $recipient->notificationPreference->comment_replies) {
+            return;
+        }
+
+        $recipient->notify(new CommentReplyNotification($comment));
+    }
+}

--- a/app/Listeners/NotifySpaceModeratorsOfReport.php
+++ b/app/Listeners/NotifySpaceModeratorsOfReport.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Enums\SpaceRole;
+use App\Events\CommentReported;
+use App\Events\PostReported;
+use App\Models\CommentReport;
+use App\Models\NotificationPreference;
+use App\Models\PostReport;
+use App\Notifications\SpaceModerationNotification;
+use Illuminate\Support\Facades\Notification;
+
+class NotifySpaceModeratorsOfReport
+{
+    public function handlePostReported(PostReported $event): void
+    {
+        $this->notify($event->report, 'post');
+    }
+
+    public function handleCommentReported(CommentReported $event): void
+    {
+        $this->notify($event->report, 'comment');
+    }
+
+    private function notify(PostReport|CommentReport $report, string $kind): void
+    {
+        $report->loadMissing('space');
+        $recipients = $report->space->members()
+            ->wherePivotIn('role', [SpaceRole::Owner->value, SpaceRole::Moderator->value])
+            ->when(
+                $report->reporter_id !== null,
+                fn ($query) => $query->whereKeyNot($report->reporter_id),
+            )
+            ->with('notificationPreference')
+            ->get()
+            ->filter(fn ($user): bool => ! ($user->notificationPreference instanceof NotificationPreference)
+                || $user->notificationPreference->space_moderation);
+
+        Notification::send(
+            $recipients,
+            new SpaceModerationNotification($report->space_id, $kind, $report->id),
+        );
+    }
+}

--- a/app/Models/NotificationPreference.php
+++ b/app/Models/NotificationPreference.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $user_id
+ * @property bool $comment_replies
+ * @property bool $space_moderation
+ * @property-read User $user
+ */
+class NotificationPreference extends Model
+{
+    protected $fillable = [
+        'comment_replies',
+        'space_moderation',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'comment_replies' => 'boolean',
+            'space_moderation' => 'boolean',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
@@ -41,6 +42,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read int $shared_space_count
+ * @property-read NotificationPreference|null $notificationPreference
  */
 #[Fillable([
     'name',
@@ -72,6 +74,10 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
             if (blank($user->handle)) {
                 $user->handle = static::availableHandle($user->name);
             }
+        });
+
+        static::deleting(function (User $user): void {
+            $user->notifications()->delete();
         });
     }
 
@@ -113,6 +119,12 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /** @return HasOne<NotificationPreference, $this> */
+    public function notificationPreference(): HasOne
+    {
+        return $this->hasOne(NotificationPreference::class);
     }
 
     /** @return HasMany<PostReport, $this> */

--- a/app/Notifications/CommentReplyNotification.php
+++ b/app/Notifications/CommentReplyNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\NotificationType;
+use App\Models\Comment;
+use Illuminate\Notifications\Notification;
+
+class CommentReplyNotification extends Notification
+{
+    public function __construct(private readonly Comment $comment) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function databaseType(object $notifiable): string
+    {
+        return NotificationType::CommentReply->value;
+    }
+
+    /** @return array{comment_id: int, post_id: int, actor_id: int, space_id: int} */
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'comment_id' => $this->comment->id,
+            'post_id' => $this->comment->post_id,
+            'actor_id' => $this->comment->user_id,
+            'space_id' => $this->comment->post->space_id,
+        ];
+    }
+}

--- a/app/Notifications/SpaceModerationNotification.php
+++ b/app/Notifications/SpaceModerationNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\NotificationType;
+use Illuminate\Notifications\Notification;
+
+class SpaceModerationNotification extends Notification
+{
+    public function __construct(
+        private readonly int $spaceId,
+        private readonly string $reportKind,
+        private readonly int $reportId,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function databaseType(object $notifiable): string
+    {
+        return NotificationType::SpaceModeration->value;
+    }
+
+    /** @return array{space_id: int, report_kind: string, report_id: int} */
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'space_id' => $this->spaceId,
+            'report_kind' => $this->reportKind,
+            'report_id' => $this->reportId,
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -76,5 +76,8 @@ class AppServiceProvider extends ServiceProvider
 
         RateLimiter::for('user-safety', fn (Request $request): Limit => Limit::perMinute(30)
             ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
+
+        RateLimiter::for('notification-actions', fn (Request $request): Limit => Limit::perMinute(60)
+            ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
     }
 }

--- a/database/migrations/2026_07_20_000009_create_notifications_table.php
+++ b/database/migrations/2026_07_20_000009_create_notifications_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('type', 80);
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['notifiable_type', 'notifiable_id', 'created_at']);
+            $table->index(['notifiable_type', 'notifiable_id', 'read_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/2026_07_20_000010_create_notification_preferences_table.php
+++ b/database/migrations/2026_07_20_000010_create_notification_preferences_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_preferences', function (Blueprint $table): void {
+            $table->foreignId('user_id')->primary()->constrained()->cascadeOnDelete();
+            $table->boolean('comment_replies')->default(true);
+            $table->boolean('space_moderation')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_preferences');
+    }
+};

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,46 @@
+# In-app notifications
+
+The first notification slice is intentionally small and useful. It alerts a
+member when another member replies to their post and alerts eligible Space owners
+or moderators when a new post or comment report needs attention.
+
+## Categories and delivery
+
+| Preference | Trigger | Recipient |
+| --- | --- | --- |
+| `comment_replies` | `CommentPublished` | The post author, unless they wrote the reply |
+| `space_moderation` | `PostReported` or `CommentReported` | Current Space owners and moderators, excluding the reporter |
+
+Both preferences default to enabled and affect new notifications only. Delivery
+uses Laravel's database channel synchronously, so the core experience does not
+require a queue worker. Email, web push, mobile push, digests, mentions, and
+reactions are not part of this release.
+
+## Privacy and authorization
+
+Notification rows store stable identifiers, not post or comment excerpts, report
+details, or reporter identity. The presentation layer resolves those identifiers
+at request time and rechecks the same policies, profile visibility, Space access,
+mute relationships, and block relationships used by the destination itself.
+
+Opening a notification is a `POST` action. The server confirms that the
+notification belongs to the authenticated member, resolves its current safe
+destination, and then marks it read. Deleted, hidden, inaccessible, or unknown
+targets render as unavailable and do not reveal their previous content.
+
+Reply destinations are calculated against the current visibility-filtered
+conversation. If later replies move the referenced comment onto an older page,
+the notification still links to the page and anchor that currently contains it.
+
+## Extension guidance
+
+Core listeners are discovered through Laravel's event discovery and remain
+separate from controllers and React pages. Extensions may listen to the same
+after-transaction domain events to add an explicitly configured transport or an
+extension-owned category.
+
+New channels should be queued when they perform I/O, remain idempotent, respect
+the member's consent and notification preferences, and repeat authorization at
+delivery time. Do not copy report details, private content, or reporter identity
+into third-party services without a deliberate administrator choice and an
+appropriate privacy basis.

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -11,6 +11,8 @@ The core owns invariants that an extension must not bypass:
 - Space visibility, roles, membership, invitations, and ownership;
 - chronological posts and comments;
 - report eligibility, moderation decisions, and append-only audit records;
+- in-app notification ownership, member preferences, read state, and safe
+  projections for core events;
 - rate limits, server validation, and policy authorization;
 - domain events emitted only after successful writes.
 
@@ -18,7 +20,10 @@ An Instagram-like product may render media-first cards, an X-like product may re
 
 ## Extension-owned capabilities
 
-Extensions may add new content projections, integrations, notifications, search indexes, analytics, commerce, learning, events, or alternative feed presentation. Extension data belongs in extension-owned tables and must reference core entities with explicit foreign keys.
+Extensions may add new content projections, integrations, notification channels,
+search indexes, analytics, commerce, learning, events, or alternative feed
+presentation. Extension data belongs in extension-owned tables and must reference
+core entities with explicit foreign keys.
 
 The current manifest is a deploy-time declaration prototype. Its permission and UI-slot allowlists document intent, but they are not yet a runtime sandbox or a supported marketplace API. No extension should be advertised as one-click installable until provider bootstrapping, migrations, compatibility checks, asset loading, failure isolation, and uninstall behavior are implemented and tested.
 
@@ -32,11 +37,17 @@ profile-visibility, and report-state boundaries while exposing comments in
 chronological 20-item pages. Feed previews link into this canonical view instead
 of attempting to load an unbounded thread inline.
 
+The notification center consumes a separate server-side projection over Laravel
+database notifications. Stored payloads contain identifiers only. Every render
+and open action resolves the current entity state, policy authorization, profile
+visibility, and Space role before exposing a destination. This lets a stale
+notification become unavailable without leaking deleted or newly restricted data.
+
 ## Near-term contract work
 
-1. Add notification events and delivery preferences without coupling them to one UI.
-2. Define media ownership, processing, privacy, and deletion before adding upload controls.
-3. Add versioned API resources for native and decoupled clients, building on the stable web conversation projection.
+1. Define media ownership, processing, privacy, and deletion before adding upload controls.
+2. Add versioned API resources for native and decoupled clients, building on the stable web conversation and notification projections.
+3. Define queued email and push delivery contracts without making the current web UI or database writes depend on an external transport.
 4. Implement and test the extension lifecycle before calling the manifest a plugin system.
 
 The goal is composability with secure defaults, not unlimited runtime code execution.

--- a/resources/js/components/social/comment-thread.tsx
+++ b/resources/js/components/social/comment-thread.tsx
@@ -134,7 +134,10 @@ export function CommentRow({
     const [reporting, setReporting] = useState(false);
 
     return (
-        <article className="group/comment flex items-start gap-2.5">
+        <article
+            id={`comment-${comment.id}`}
+            className="group/comment flex scroll-mt-24 items-start gap-2.5"
+        >
             <AvatarMark name={comment.author.name} className="mt-0.5 size-8" />
             <div className="min-w-0 flex-1">
                 <div className="rounded-2xl rounded-tl-md bg-secondary/58 px-3.5 py-2.5">

--- a/resources/js/components/social/social-nav.tsx
+++ b/resources/js/components/social/social-nav.tsx
@@ -1,5 +1,6 @@
 import { Link, usePage } from '@inertiajs/react';
 import {
+    Bell,
     Compass,
     Feather,
     Home,
@@ -32,6 +33,12 @@ const navItems = [
         subtitle: 'Discover members',
         href: '/people',
         icon: UsersRound,
+    },
+    {
+        title: 'Notifications',
+        subtitle: 'Updates that matter',
+        href: '/notifications',
+        icon: Bell,
     },
 ] as const;
 
@@ -97,7 +104,7 @@ function UserButton({
 }
 
 export function DesktopSocialNav() {
-    const { auth } = usePage().props;
+    const { auth, notificationSummary } = usePage().props;
     const { isCurrentOrParentUrl } = useCurrentUrl();
 
     return (
@@ -112,6 +119,10 @@ export function DesktopSocialNav() {
                     {navItems.map((item) => {
                         const active = isCurrentOrParentUrl(item.href);
                         const Icon = item.icon;
+                        const unreadCount =
+                            item.href === '/notifications'
+                                ? notificationSummary.unreadCount
+                                : 0;
 
                         return (
                             <Link
@@ -147,6 +158,11 @@ export function DesktopSocialNav() {
                                         {item.subtitle}
                                     </span>
                                 </span>
+                                {unreadCount > 0 && (
+                                    <span className="flex min-w-6 items-center justify-center rounded-full bg-coral px-1.5 py-1 text-[0.62rem] font-black text-white tabular-nums">
+                                        {unreadCount > 99 ? '99+' : unreadCount}
+                                    </span>
+                                )}
                                 {active && (
                                     <span className="absolute top-1/2 -right-3 h-7 w-1 -translate-y-1/2 rounded-l-full bg-primary" />
                                 )}
@@ -185,7 +201,7 @@ export function DesktopSocialNav() {
 }
 
 export function MobileSocialHeader() {
-    const { auth } = usePage().props;
+    const { auth, notificationSummary } = usePage().props;
 
     return (
         <header className="sticky top-0 z-40 flex h-[4.25rem] items-center justify-between border-b border-border/65 bg-card/88 px-4 backdrop-blur-xl lg:hidden">
@@ -194,7 +210,19 @@ export function MobileSocialHeader() {
                 Lineweb Social
             </span>
             {auth.user ? (
-                <UserButton user={auth.user} compact />
+                <div className="flex items-center gap-1.5">
+                    <Link
+                        href="/notifications"
+                        aria-label={`Notifications${notificationSummary.unreadCount > 0 ? `, ${notificationSummary.unreadCount} unread` : ''}`}
+                        className="social-focus relative flex size-10 items-center justify-center rounded-full text-foreground transition-colors hover:bg-secondary"
+                    >
+                        <Bell className="size-5" aria-hidden="true" />
+                        {notificationSummary.unreadCount > 0 && (
+                            <span className="absolute top-1.5 right-1.5 size-2.5 rounded-full bg-coral ring-2 ring-card" />
+                        )}
+                    </Link>
+                    <UserButton user={auth.user} compact />
+                </div>
             ) : (
                 <Link
                     href="/login"

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@inertiajs/react';
-import { Palette, ShieldCheck, UserRound, UserX } from 'lucide-react';
+import { BellRing, Palette, ShieldCheck, UserRound, UserX } from 'lucide-react';
 import type { PropsWithChildren } from 'react';
 import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
@@ -31,6 +31,11 @@ const sidebarNavItems: NavItem[] = [
         title: 'Safety',
         href: '/settings/safety',
         icon: UserX,
+    },
+    {
+        title: 'Notifications',
+        href: '/settings/notifications',
+        icon: BellRing,
     },
 ];
 

--- a/resources/js/pages/notifications/index.tsx
+++ b/resources/js/pages/notifications/index.tsx
@@ -1,0 +1,353 @@
+import { Head, Link, router } from '@inertiajs/react';
+import {
+    BellOff,
+    BellRing,
+    Check,
+    ChevronLeft,
+    ChevronRight,
+    Flag,
+    MessageCircle,
+    Settings2,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type NotificationItem = {
+    id: string;
+    kind: 'comment_reply' | 'space_moderation' | 'unavailable';
+    title: string;
+    description: string;
+    createdAt: string;
+    readAt: string | null;
+    available: boolean;
+};
+
+type NotificationsProps = {
+    items: NotificationItem[];
+    meta: {
+        currentPage: number;
+        lastPage: number;
+        perPage: number;
+        total: number;
+    };
+    links: {
+        previous: string | null;
+        next: string | null;
+    };
+    filter: 'all' | 'unread';
+    notificationSummary: { unreadCount: number };
+    status?: string;
+};
+
+const timestamp = (value: string) =>
+    new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(new Date(value));
+
+export default function Notifications({
+    items,
+    meta,
+    links,
+    filter,
+    notificationSummary,
+    status,
+}: NotificationsProps) {
+    const unreadCount = notificationSummary.unreadCount;
+
+    return (
+        <>
+            <Head title="Notifications" />
+            <main className="social-page max-w-5xl">
+                <header className="social-page-heading">
+                    <div className="flex flex-wrap items-end justify-between gap-4">
+                        <div>
+                            <p className="social-eyebrow">
+                                <BellRing className="size-3.5" />
+                                Your inbox
+                            </p>
+                            <h1 className="mt-2 text-3xl font-black tracking-[-0.04em] sm:text-4xl">
+                                Notifications
+                            </h1>
+                            <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+                                Replies and moderation work that deserve your
+                                attention — no engagement ranking or noise.
+                            </p>
+                        </div>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            disabled={unreadCount === 0}
+                            onClick={() =>
+                                router.patch('/notifications/read-all')
+                            }
+                            className="min-h-11 rounded-xl"
+                        >
+                            <Check className="size-4" aria-hidden="true" />
+                            Mark all read
+                        </Button>
+                    </div>
+                </header>
+
+                {status && (
+                    <div
+                        role="status"
+                        className="mt-5 rounded-2xl border border-primary/20 bg-primary/8 px-4 py-3 text-sm font-bold"
+                    >
+                        {status}
+                    </div>
+                )}
+
+                <div className="mt-5 grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_17rem]">
+                    <section
+                        className="social-card min-w-0 overflow-hidden rounded-[1.5rem]"
+                        aria-labelledby="notification-list-title"
+                    >
+                        <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-4 sm:px-5">
+                            <div>
+                                <h2
+                                    id="notification-list-title"
+                                    className="font-black tracking-tight"
+                                >
+                                    Recent activity
+                                </h2>
+                                <p className="mt-0.5 text-xs font-semibold text-muted-foreground">
+                                    {unreadCount.toLocaleString()} unread
+                                </p>
+                            </div>
+                            <div className="flex rounded-xl bg-secondary/70 p-1">
+                                <FilterLink
+                                    href="/notifications"
+                                    active={filter === 'all'}
+                                >
+                                    All
+                                </FilterLink>
+                                <FilterLink
+                                    href="/notifications?filter=unread"
+                                    active={filter === 'unread'}
+                                >
+                                    Unread
+                                </FilterLink>
+                            </div>
+                        </div>
+
+                        {items.length === 0 ? (
+                            <div className="px-5 py-16 text-center">
+                                <span className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-secondary text-primary">
+                                    <BellRing
+                                        className="size-6"
+                                        aria-hidden="true"
+                                    />
+                                </span>
+                                <h3 className="mt-4 font-black">
+                                    {filter === 'unread'
+                                        ? 'You are all caught up.'
+                                        : 'Nothing here yet.'}
+                                </h3>
+                                <p className="mx-auto mt-1 max-w-sm text-sm leading-6 text-muted-foreground">
+                                    Useful replies and moderation alerts will
+                                    appear here when they happen.
+                                </p>
+                            </div>
+                        ) : (
+                            <ul className="divide-y divide-border/75">
+                                {items.map((item) => (
+                                    <NotificationRow
+                                        key={item.id}
+                                        item={item}
+                                    />
+                                ))}
+                            </ul>
+                        )}
+
+                        {meta.lastPage > 1 && (
+                            <nav
+                                className="flex items-center justify-between gap-3 border-t px-4 py-4 sm:px-5"
+                                aria-label="Notification pages"
+                            >
+                                {links.previous ? (
+                                    <PageLink href={links.previous}>
+                                        <ChevronLeft className="size-4" />
+                                        Newer
+                                    </PageLink>
+                                ) : (
+                                    <span />
+                                )}
+                                <span className="text-xs font-bold text-muted-foreground">
+                                    Page {meta.currentPage} of {meta.lastPage}
+                                </span>
+                                {links.next ? (
+                                    <PageLink href={links.next}>
+                                        Older
+                                        <ChevronRight className="size-4" />
+                                    </PageLink>
+                                ) : (
+                                    <span />
+                                )}
+                            </nav>
+                        )}
+                    </section>
+
+                    <aside className="space-y-4 lg:sticky lg:top-5">
+                        <div className="social-card rounded-[1.35rem] p-5">
+                            <p className="text-xs font-extrabold tracking-[0.12em] text-primary uppercase">
+                                Low-noise by design
+                            </p>
+                            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                                This inbox contains direct replies and
+                                moderation work. Likes, popularity scores, and
+                                algorithmic nudges are intentionally absent.
+                            </p>
+                        </div>
+                        <Button
+                            asChild
+                            variant="outline"
+                            className="min-h-11 w-full justify-start rounded-xl"
+                        >
+                            <Link href="/settings/notifications">
+                                <Settings2
+                                    className="size-4"
+                                    aria-hidden="true"
+                                />
+                                Notification settings
+                            </Link>
+                        </Button>
+                    </aside>
+                </div>
+            </main>
+        </>
+    );
+}
+
+function FilterLink({
+    href,
+    active,
+    children,
+}: {
+    href: string;
+    active: boolean;
+    children: string;
+}) {
+    return (
+        <Link
+            href={href}
+            preserveState
+            className={cn(
+                'social-focus flex min-h-9 items-center rounded-lg px-3 text-xs font-extrabold transition-colors',
+                active
+                    ? 'bg-card text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+            )}
+        >
+            {children}
+        </Link>
+    );
+}
+
+function NotificationRow({ item }: { item: NotificationItem }) {
+    const unread = item.readAt === null;
+    const Icon =
+        item.kind === 'comment_reply'
+            ? MessageCircle
+            : item.kind === 'space_moderation'
+              ? Flag
+              : BellOff;
+
+    return (
+        <li
+            className={cn(
+                'relative px-4 py-4 transition-colors sm:px-5',
+                unread && 'bg-primary/[0.035]',
+            )}
+        >
+            {unread && (
+                <span
+                    className="absolute top-5 left-1.5 size-2 rounded-full bg-coral"
+                    aria-label="Unread"
+                />
+            )}
+            <div className="flex items-start gap-3.5">
+                <span
+                    className={cn(
+                        'flex size-11 shrink-0 items-center justify-center rounded-2xl',
+                        item.kind === 'comment_reply'
+                            ? 'bg-primary/10 text-primary'
+                            : item.kind === 'space_moderation'
+                              ? 'bg-coral/12 text-coral'
+                              : 'bg-secondary text-muted-foreground',
+                    )}
+                >
+                    <Icon className="size-5" aria-hidden="true" />
+                </span>
+                <div className="min-w-0 flex-1">
+                    <p
+                        className={cn(
+                            'text-sm tracking-tight',
+                            unread ? 'font-black' : 'font-bold',
+                        )}
+                    >
+                        {item.title}
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                        {item.description}
+                    </p>
+                    <time
+                        dateTime={item.createdAt}
+                        className="mt-2 block text-xs font-semibold text-muted-foreground"
+                    >
+                        {timestamp(item.createdAt)}
+                    </time>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                        {item.available && (
+                            <Button
+                                type="button"
+                                size="sm"
+                                className="min-h-10 rounded-xl"
+                                onClick={() =>
+                                    router.post(
+                                        `/notifications/${item.id}/open`,
+                                    )
+                                }
+                            >
+                                Open
+                            </Button>
+                        )}
+                        {unread && (
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                className="min-h-10 rounded-xl"
+                                onClick={() =>
+                                    router.patch(
+                                        `/notifications/${item.id}/read`,
+                                        {},
+                                        { preserveScroll: true },
+                                    )
+                                }
+                            >
+                                Mark as read
+                            </Button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </li>
+    );
+}
+
+function PageLink({ href, children }: { href: string; children: ReactNode }) {
+    return (
+        <Link
+            href={href}
+            className="social-focus inline-flex min-h-10 items-center gap-1.5 rounded-xl border px-3 text-xs font-extrabold transition-colors hover:bg-secondary"
+        >
+            {children}
+        </Link>
+    );
+}
+
+Notifications.layout = {
+    breadcrumbs: [{ title: 'Notifications', href: '/notifications' }],
+};

--- a/resources/js/pages/settings/notifications.tsx
+++ b/resources/js/pages/settings/notifications.tsx
@@ -1,0 +1,136 @@
+import { Head, useForm } from '@inertiajs/react';
+import { BellRing, Flag, MessageCircle } from 'lucide-react';
+import type { FormEvent } from 'react';
+import Heading from '@/components/heading';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+
+type NotificationPreferencesProps = {
+    preferences: {
+        commentReplies: boolean;
+        spaceModeration: boolean;
+    };
+    status?: string;
+};
+
+export default function NotificationPreferences({
+    preferences,
+    status,
+}: NotificationPreferencesProps) {
+    const { data, setData, patch, processing, isDirty, recentlySuccessful } =
+        useForm({
+            comment_replies: preferences.commentReplies,
+            space_moderation: preferences.spaceModeration,
+        });
+
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        patch('/settings/notifications', { preserveScroll: true });
+    };
+
+    return (
+        <>
+            <Head title="Notification settings" />
+            <div className="space-y-7">
+                <Heading
+                    variant="small"
+                    title="Notifications"
+                    description="Choose which useful updates reach your in-app inbox. Email delivery is not enabled in this release."
+                />
+
+                {status && (
+                    <div
+                        role="status"
+                        className="rounded-2xl border border-primary/20 bg-primary/8 px-4 py-3 text-sm font-bold"
+                    >
+                        {status}
+                    </div>
+                )}
+
+                <form onSubmit={submit} className="space-y-5">
+                    <div className="space-y-3">
+                        <PreferenceRow
+                            icon={MessageCircle}
+                            title="Replies to your posts"
+                            description="Know when another member adds a comment to a post you authored. Your own comments never create an alert."
+                            checked={data.comment_replies}
+                            onCheckedChange={(checked) =>
+                                setData('comment_replies', checked)
+                            }
+                        />
+                        <PreferenceRow
+                            icon={Flag}
+                            title="Space moderation reports"
+                            description="Alert you when a post or comment needs review in a Space you own or moderate. Reporter identity is not included."
+                            checked={data.space_moderation}
+                            onCheckedChange={(checked) =>
+                                setData('space_moderation', checked)
+                            }
+                        />
+                    </div>
+
+                    <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-5">
+                        <p className="inline-flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+                            <BellRing className="size-4" aria-hidden="true" />
+                            Changes affect new notifications only.
+                        </p>
+                        <Button
+                            type="submit"
+                            disabled={processing || !isDirty}
+                            className="min-h-11 rounded-xl"
+                        >
+                            {recentlySuccessful
+                                ? 'Preferences saved'
+                                : 'Save preferences'}
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </>
+    );
+}
+
+function PreferenceRow({
+    icon: Icon,
+    title,
+    description,
+    checked,
+    onCheckedChange,
+}: {
+    icon: typeof BellRing;
+    title: string;
+    description: string;
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+}) {
+    return (
+        <label className="group flex cursor-pointer items-start gap-4 rounded-2xl border border-border/75 bg-background p-4 transition-colors hover:border-primary/20 hover:bg-primary/[0.025] sm:p-5">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-secondary text-primary">
+                <Icon className="size-4.5" aria-hidden="true" />
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block font-extrabold tracking-tight">
+                    {title}
+                </span>
+                <span className="mt-1 block text-sm leading-6 text-muted-foreground">
+                    {description}
+                </span>
+            </span>
+            <Checkbox
+                checked={checked}
+                onCheckedChange={(value) => onCheckedChange(value === true)}
+                aria-label={title}
+                className="mt-1 size-5"
+            />
+        </label>
+    );
+}
+
+NotificationPreferences.layout = {
+    breadcrumbs: [
+        {
+            title: 'Notification settings',
+            href: '/settings/notifications',
+        },
+    ],
+};

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -12,6 +12,9 @@ declare module '@inertiajs/core' {
         sharedPageProps: {
             name: string;
             auth: Auth;
+            notificationSummary: {
+                unreadCount: number;
+            };
             sidebarOpen: boolean;
             [key: string]: unknown;
         };

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\NotificationPreferencesController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SafetyController;
 use App\Http\Controllers\Settings\SecurityController;
@@ -26,6 +27,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::inertia('settings/appearance', 'settings/appearance')->name('appearance.edit');
     Route::get('settings/safety', SafetyController::class)->name('safety.edit');
+    Route::get('settings/notifications', [NotificationPreferencesController::class, 'edit'])
+        ->name('notification-preferences.edit');
+    Route::patch('settings/notifications', [NotificationPreferencesController::class, 'update'])
+        ->name('notification-preferences.update');
 });
 
 Route::get('.well-known/passkey-endpoints', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\CommentController;
 use App\Http\Controllers\CommentReportController;
 use App\Http\Controllers\CommentReportModerationController;
 use App\Http\Controllers\FeedController;
+use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\PeopleController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\PostReportController;
@@ -22,6 +23,19 @@ Route::inertia('/', 'welcome')->name('home');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('feed', FeedController::class)->name('feed');
+    Route::get('notifications', [NotificationController::class, 'index'])
+        ->name('notifications.index');
+    Route::post('notifications/{notification}/open', [NotificationController::class, 'open'])
+        ->whereUuid('notification')
+        ->middleware('throttle:notification-actions')
+        ->name('notifications.open');
+    Route::patch('notifications/{notification}/read', [NotificationController::class, 'read'])
+        ->whereUuid('notification')
+        ->middleware('throttle:notification-actions')
+        ->name('notifications.read');
+    Route::patch('notifications/read-all', [NotificationController::class, 'readAll'])
+        ->middleware('throttle:notification-actions')
+        ->name('notifications.read-all');
     Route::get('people', [PeopleController::class, 'index'])->name('people.index');
     Route::get('people/{profile:handle}', [PeopleController::class, 'show'])->name('people.show');
     Route::post('people/{profile:handle}/mute', [UserRelationshipController::class, 'mute'])

--- a/tests/Feature/NotificationCenterTest.php
+++ b/tests/Feature/NotificationCenterTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ReportReason;
+use App\Enums\SpaceRole;
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\Space;
+use App\Models\User;
+use App\Notifications\CommentReplyNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class NotificationCenterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_commenting_notifies_the_post_author_without_storing_content(): void
+    {
+        $author = User::factory()->create();
+        $commenter = User::factory()->create(['name' => 'Thoughtful Member']);
+        $space = Space::factory()->for($author, 'owner')->create(['name' => 'Makers Circle']);
+        $space->addMember($commenter);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+
+        $this->actingAs($commenter)
+            ->post(route('posts.comments.store', $post), [
+                'body' => 'A private body that should not be copied into notifications.',
+            ])
+            ->assertRedirect();
+
+        $notification = DatabaseNotification::query()
+            ->where('notifiable_id', $author->id)
+            ->sole();
+
+        $this->assertSame('comment_reply', $notification->type);
+        $this->assertSame(
+            ['actor_id', 'comment_id', 'post_id', 'space_id'],
+            array_keys(collect($notification->data)->sortKeys()->all()),
+        );
+        $this->assertSame($commenter->id, $notification->data['actor_id']);
+        $this->assertStringNotContainsString('private body', json_encode($notification->data, JSON_THROW_ON_ERROR));
+
+        $this->actingAs($author)
+            ->get(route('notifications.index'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('notifications/index')
+                ->where('notificationSummary.unreadCount', 1)
+                ->where('filter', 'all')
+                ->has('items', 1)
+                ->where('items.0.kind', 'comment_reply')
+                ->where('items.0.title', 'Thoughtful Member replied to your post')
+                ->where('items.0.description', 'Open the conversation in Makers Circle.')
+                ->where('items.0.available', true)
+                ->where('items.0.readAt', null));
+    }
+
+    public function test_self_replies_mutes_and_disabled_preferences_do_not_create_notifications(): void
+    {
+        $commenter = User::factory()->create();
+
+        $selfAuthor = User::factory()->create();
+        $selfSpace = Space::factory()->for($selfAuthor, 'owner')->create();
+        $selfPost = Post::factory()->for($selfSpace)->for($selfAuthor, 'author')->create();
+        $this->actingAs($selfAuthor)
+            ->post(route('posts.comments.store', $selfPost), ['body' => 'My own follow-up.'])
+            ->assertRedirect();
+
+        $mutingAuthor = User::factory()->create();
+        $mutingSpace = Space::factory()->for($mutingAuthor, 'owner')->create();
+        $mutingSpace->addMember($commenter);
+        $mutingPost = Post::factory()->for($mutingSpace)->for($mutingAuthor, 'author')->create();
+        $mutingAuthor->outgoingRelationships()->create([
+            'target_id' => $commenter->id,
+            'type' => 'mute',
+        ]);
+        $this->actingAs($commenter)
+            ->post(route('posts.comments.store', $mutingPost), ['body' => 'Muted reply.'])
+            ->assertRedirect();
+
+        $quietAuthor = User::factory()->create();
+        $quietSpace = Space::factory()->for($quietAuthor, 'owner')->create();
+        $quietSpace->addMember($commenter);
+        $quietPost = Post::factory()->for($quietSpace)->for($quietAuthor, 'author')->create();
+        $quietAuthor->notificationPreference()->create([
+            'comment_replies' => false,
+            'space_moderation' => true,
+        ]);
+        $this->actingAs($commenter)
+            ->post(route('posts.comments.store', $quietPost), ['body' => 'Preference-disabled reply.'])
+            ->assertRedirect();
+
+        $this->assertDatabaseCount('notifications', 0);
+    }
+
+    public function test_reports_notify_only_eligible_moderators_without_reporter_details(): void
+    {
+        $owner = User::factory()->create();
+        $moderator = User::factory()->create();
+        $member = User::factory()->create();
+        $reporter = User::factory()->create();
+        $author = User::factory()->create();
+        $space = Space::factory()->for($owner, 'owner')->create();
+        $space->addMember($moderator, SpaceRole::Moderator);
+        $space->addMember($member);
+        $moderator->notificationPreference()->create([
+            'comment_replies' => true,
+            'space_moderation' => false,
+        ]);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+
+        $this->actingAs($reporter)
+            ->post(route('posts.reports.store', $post), [
+                'reason' => ReportReason::Privacy->value,
+                'details' => 'Sensitive reporter context.',
+            ])
+            ->assertRedirect();
+
+        $notification = DatabaseNotification::query()->sole();
+        $this->assertSame($owner->id, $notification->notifiable_id);
+        $this->assertSame('space_moderation', $notification->type);
+        $this->assertSame(
+            ['report_id', 'report_kind', 'space_id'],
+            array_keys(collect($notification->data)->sortKeys()->all()),
+        );
+        $this->assertSame('post', $notification->data['report_kind']);
+        $payload = json_encode($notification->data, JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString((string) $reporter->id, $payload);
+        $this->assertStringNotContainsString('Sensitive reporter context', $payload);
+
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $moderator->id]);
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $member->id]);
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $reporter->id]);
+    }
+
+    public function test_notification_actions_are_owner_scoped_and_manage_read_state(): void
+    {
+        $recipient = User::factory()->create();
+        $other = User::factory()->create();
+        $author = User::factory()->create();
+        $space = Space::factory()->for($recipient, 'owner')->create();
+        $post = Post::factory()->for($space)->for($recipient, 'author')->create();
+        $comment = Comment::factory()->for($post)->for($author, 'author')->create();
+        $recipient->notify(new CommentReplyNotification($comment));
+        $first = DatabaseNotification::query()->sole();
+
+        $this->actingAs($other)
+            ->patch(route('notifications.read', $first->id))
+            ->assertNotFound();
+
+        $this->actingAs($recipient)
+            ->patch(route('notifications.read', $first->id))
+            ->assertRedirect();
+        $this->assertNotNull($first->refresh()->read_at);
+
+        $recipient->notify(new CommentReplyNotification($comment));
+        $second = DatabaseNotification::query()->whereNull('read_at')->sole();
+
+        $this->actingAs($recipient)
+            ->patch(route('notifications.read-all'))
+            ->assertRedirect();
+        $this->assertDatabaseMissing('notifications', [
+            'notifiable_id' => $recipient->id,
+            'read_at' => null,
+        ]);
+
+        $second->markAsUnread();
+        $this->actingAs($recipient)
+            ->post(route('notifications.open', $second->id))
+            ->assertRedirect(route('posts.show', $post).'#comment-'.$comment->id);
+        $this->assertNotNull($second->refresh()->read_at);
+    }
+
+    public function test_reply_opening_resolves_the_page_that_currently_contains_the_comment(): void
+    {
+        $recipient = User::factory()->create();
+        $commenter = User::factory()->create();
+        $space = Space::factory()->for($recipient, 'owner')->create();
+        $post = Post::factory()->for($space)->for($recipient, 'author')->create();
+        $target = Comment::factory()->for($post)->for($commenter, 'author')->create();
+
+        Comment::factory()->count(20)->for($post)->for($commenter, 'author')->create();
+        $recipient->notify(new CommentReplyNotification($target));
+        $notification = DatabaseNotification::query()->sole();
+
+        $this->actingAs($recipient)
+            ->post(route('notifications.open', $notification->id))
+            ->assertRedirect(route('posts.show', ['post' => $post, 'page' => 2]).'#comment-'.$target->id);
+    }
+
+    public function test_stale_notifications_do_not_expose_deleted_or_inaccessible_targets(): void
+    {
+        $recipient = User::factory()->create();
+        $commenter = User::factory()->create();
+        $space = Space::factory()->for($recipient, 'owner')->create();
+        $post = Post::factory()->for($space)->for($recipient, 'author')->create();
+        $comment = Comment::factory()->for($post)->for($commenter, 'author')->create();
+        $recipient->notify(new CommentReplyNotification($comment));
+        $notification = DatabaseNotification::query()->sole();
+        $comment->delete();
+
+        $this->actingAs($recipient)
+            ->get(route('notifications.index'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('items.0.kind', 'unavailable')
+                ->where('items.0.available', false)
+                ->where('items.0.title', 'Notification unavailable'));
+
+        $this->actingAs($recipient)
+            ->post(route('notifications.open', $notification->id))
+            ->assertRedirect(route('notifications.index'))
+            ->assertSessionHas('status', 'This notification is no longer available.');
+    }
+}

--- a/tests/Feature/Settings/NotificationPreferencesTest.php
+++ b/tests/Feature/Settings/NotificationPreferencesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class NotificationPreferencesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_notification_preferences_default_to_enabled_and_can_be_updated(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('notification-preferences.edit'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('settings/notifications')
+                ->where('preferences.commentReplies', true)
+                ->where('preferences.spaceModeration', true));
+
+        $this->actingAs($user)
+            ->patch(route('notification-preferences.update'), [
+                'comment_replies' => false,
+                'space_moderation' => false,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Notification preferences saved.');
+
+        $this->assertDatabaseHas('notification_preferences', [
+            'user_id' => $user->id,
+            'comment_replies' => false,
+            'space_moderation' => false,
+        ]);
+    }
+
+    public function test_notification_preference_input_is_complete_and_boolean(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->patch(route('notification-preferences.update'), [
+                'comment_replies' => 'sometimes',
+            ])
+            ->assertSessionHasErrors(['comment_replies', 'space_moderation']);
+
+        $this->assertDatabaseCount('notification_preferences', 0);
+    }
+
+    public function test_unverified_accounts_cannot_open_notification_settings(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        $this->actingAs($user)
+            ->get(route('notification-preferences.edit'))
+            ->assertRedirect(route('verification.notice'));
+    }
+}


### PR DESCRIPTION
## Why

Useful communities need timely context without copying private content into another engagement feed. This adds a deliberately small notification foundation for direct replies and moderation work.

## What changed

- Adds database notifications for replies to a member's posts and new Space reports.
- Adds per-member reply and moderation preferences.
- Adds unread counts, all/unread filters, read/read-all actions, and responsive desktop/mobile navigation.
- Re-authorizes every notification when it is rendered or opened. Stored payloads contain identifiers only—no comment body, report details, or reporter identity.
- Resolves reply links to the current visibility-filtered conversation page and comment anchor.
- Documents the notification contract and leaves email/push delivery out of this release.

## Validation

- 103 PHP tests, 797 assertions
- Pint and PHPStan
- ESLint, Prettier, and TypeScript
- Production Vite build
- Browser QA at 1440×900 and 390×844
- Verified unread filtering, 2→1→0 badge updates, read/read-all, secure reply/moderation destinations, comment anchoring, and preference save/restore