### PR TITLE
Define the API v1 contract before exposing endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable project changes will be documented here.
 
 ### Added
 
+- A contract-first authenticated `/api/v1` draft with explicit token lifecycle,
+  abilities, cursor pagination, throttling, CORS, error, and policy-safe
+  serialization boundaries, plus a machine-readable OpenAPI 3.1 skeleton and
+  contract regression tests. All operations remain marked as planned.
 - Optional single-image post attachments with required alternative text,
   private policy-protected delivery, bounded processing, and static WebP
   normalization that discards original metadata and filenames.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Post images are decoded from untrusted uploads, normalized to static WebP, kept
 on a private disk, and authorized through their parent post. See
 [`docs/media.md`](docs/media.md) for the limits, lifecycle, and storage contract.
 
+The first authenticated native/decoupled API is being developed contract-first.
+Its read-only draft fixes the `/api/v1` boundary, expiring token abilities,
+cursor pagination, throttling, CORS, stable errors, and policy-safe resources
+before any endpoint is exposed. See [`docs/api-v1.md`](docs/api-v1.md) and the
+machine-readable [`docs/openapi.json`](docs/openapi.json). Every documented
+operation remains explicitly marked `planned` until implementation and tests
+are complete.
+
 The core owns identity, Spaces, visibility, safety relationships, conversations, and moderation. Product-specific experiences—photo grids, short-video feeds, professional timelines, events, commerce, or learning—should build on those boundaries through presentation layers and extensions rather than weakening core policies. See [`docs/platform-architecture.md`](docs/platform-architecture.md) for the current separation and the contracts that still need to mature.
 
 ## Contributing

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -1,0 +1,238 @@
+# API v1 contract
+
+## Status
+
+This document defines the first public contract for authenticated native and
+decoupled clients. The endpoints in `openapi.json` are **planned, not yet
+implemented**. Contract-first development keeps client expectations separate
+from the current Inertia view models and prevents accidental exposure of raw
+database records.
+
+The first implementation slice is deliberately read-only. Write operations,
+interactive native login, third-party OAuth, webhooks, and realtime delivery
+need separate reviews before they enter the contract.
+
+## Compatibility boundary
+
+- Every endpoint is rooted at `/api/v1`.
+- Removing a field, changing its type, tightening an enum, or changing ordering
+  is a breaking change and requires a new API version.
+- Adding an optional field is allowed within v1. Clients must ignore fields they
+  do not understand.
+- Identifiers are serialized as strings even when the current database uses
+  integers. Clients must treat cursors and identifiers as opaque values.
+- API field names use `snake_case`. Existing Inertia page props are an internal
+  web contract and may continue to use `camelCase`.
+- All timestamps are UTC ISO 8601 strings.
+
+The canonical machine-readable draft is [`openapi.json`](openapi.json). The
+document uses OpenAPI 3.1 so it can be validated with an ordinary JSON parser
+without adding a runtime documentation dependency.
+
+## Authentication and token lifecycle
+
+The existing first-party Inertia application continues to use Fortify session
+authentication, verified email, passkeys, two-factor authentication, CSRF
+protection, and the current login throttles.
+
+API v1 will use Laravel Sanctum bearer tokens for native, automation, and
+decoupled clients. The first alpha will not accept an email and password at an
+API token endpoint. Tokens will instead be created from a verified web session
+after recent authentication. This avoids creating a second login path that
+bypasses Fortify's passkey or two-factor challenges.
+
+Token rules:
+
+- store only Sanctum's token digest and show the plaintext value once;
+- require a human-readable device or integration name;
+- expire after 30 days by default and never exceed 90 days;
+- allow at most 10 active tokens per account;
+- provide per-token and revoke-all controls in account security settings;
+- revoke all tokens after account deletion or password-reset recovery;
+- prune expired records on the scheduler;
+- never issue wildcard (`*`) abilities to user-created tokens.
+
+Interactive native authentication remains a later decision. If third-party
+public clients are supported, use an authorization flow designed for public
+clients, such as Authorization Code with PKCE, rather than collecting the
+member's password inside another application.
+
+## Token abilities
+
+The read-only slice recognizes these abilities:
+
+| Ability | Access |
+| --- | --- |
+| `profile:read` | The authenticated member's own safe profile. |
+| `profiles:read` | Profiles already visible to the member. |
+| `spaces:read` | Discoverable Spaces and viewer membership state. |
+| `feed:read` | Policy-filtered feed, posts, comments, and private post media. |
+| `notifications:read` | The member's policy-resolved notification history. |
+
+Abilities are an additional boundary, not authorization by themselves. Every
+request must still pass the same policies, visibility scopes, membership rules,
+mute/block boundaries, and moderation state as the web application.
+
+Future write abilities are reserved but are not granted or accepted by the
+first slice: `posts:write`, `comments:write`, `memberships:write`,
+`relationships:write`, and `notifications:write`.
+
+## Response shape
+
+Single resources use:
+
+```json
+{
+  "data": {}
+}
+```
+
+Collections use opaque cursor pagination:
+
+```json
+{
+  "data": [],
+  "links": {
+    "next": "/api/v1/feed?cursor=opaque-value&limit=20"
+  },
+  "meta": {
+    "next_cursor": "opaque-value",
+    "has_more": true,
+    "limit": 20
+  }
+}
+```
+
+Clients must follow `links.next` or return `meta.next_cursor` unchanged. They
+must not decode cursors or construct one from an identifier or timestamp. Feed,
+notifications, and profile activity use `(published_at DESC, id DESC)` or the
+equivalent creation timestamp. Conversation comments use
+`(published_at ASC, id ASC)`. The identifier is always the deterministic
+tie-breaker.
+
+Validation and other errors use one stable envelope:
+
+```json
+{
+  "message": "The request could not be completed.",
+  "code": "validation_failed",
+  "request_id": "019f6f09-7f6b-7f4d-a277-8956332f6fb7",
+  "errors": {
+    "limit": ["The limit must be between 1 and 50."]
+  }
+}
+```
+
+`errors` is present only for field-level validation. Production errors never
+contain exception messages, stack traces, SQL, filesystem paths, internal model
+names, or policy details. Responses include the same opaque `X-Request-ID` in
+the header for support correlation.
+
+Standard status codes are `200`, `400`, `401`, `403`, `404`, `422`, and `429`.
+The API uses `404` instead of confirming that inaccessible private content
+exists when that distinction would leak information.
+
+## Pagination and limits
+
+- Collection limits default to 20 and are capped at 50.
+- Cursors are scoped to the authenticated member, filters, ordering, and API
+  version. Reusing one with different filters returns `400 invalid_cursor`.
+- Offset pagination is not part of API v1.
+- Feed and notification queries must apply visibility before pagination so
+  filtering cannot produce cross-page leaks or unstable counts.
+- Total counts are omitted from cursor collections unless they are already
+  cheap, policy-safe, and necessary to the product surface.
+
+## Throttling
+
+The first implementation will apply named Laravel limiters using the
+authenticated member and current token identifier, with IP fallback before
+authentication:
+
+| Class | Initial ceiling |
+| --- | --- |
+| Normal JSON reads | 120 requests per minute |
+| Discovery/search-style reads | 30 requests per minute |
+| Private media delivery | 120 requests per minute plus infrastructure bandwidth limits |
+| Future writes | Separate endpoint-specific limiters, never the read bucket |
+
+Successful and throttled responses expose `RateLimit-Limit`,
+`RateLimit-Remaining`, and `RateLimit-Reset`. A `429` response also includes
+`Retry-After`. Limits are deployment defaults, not a promise that every
+installation has identical capacity.
+
+## CORS and transport
+
+- Production API traffic requires HTTPS.
+- Browser origins are an explicit environment allowlist; `*` is not a valid
+  production origin.
+- Bearer-token API routes do not enable credentialed cross-origin cookies.
+- The existing same-origin Inertia session remains on the web middleware stack
+  and is not converted into a cross-origin API session.
+- Native clients are not governed by browser CORS, but receive no weaker auth,
+  rate-limit, or policy treatment.
+- Authentication tokens, cursor values, and private media URLs must not appear
+  in application logs, analytics events, or referrer-bearing public links.
+
+## Policy-safe serialization
+
+Controllers must return explicit Laravel API Resources or equally strict typed
+projection objects. Returning Eloquent models, database notifications, or
+`toArray()` output directly is forbidden.
+
+The first resources expose only allowlisted fields:
+
+- profiles exclude email, verification state, privacy configuration, login
+  metadata, relationship rows, and undiscoverable membership;
+- Spaces exclude invitation recipients, audit records, and hidden membership;
+- posts and comments exclude storage paths, report details, moderator notes,
+  hidden timestamps, and author account identifiers;
+- media exposes only the authorized API URL, alt text, normalized dimensions,
+  and MIME type;
+- notifications are re-resolved at read time and expose a safe structured
+  target or `null`, never their stored internal payload.
+
+The API must not trust a resource serialized earlier. It rechecks access on
+every request, including private media delivery and notification destinations.
+Blocked or muted actors, hidden content, revoked membership, and deleted targets
+must disappear according to the existing core policies.
+
+Private media remains bearer-authenticated in v1. A decoupled browser client
+must fetch the image with its API client and render a local object URL; placing
+the API URL directly in an `<img>` element will not attach the bearer token.
+Public or long-lived signed media URLs are intentionally outside this draft.
+
+## Read-only endpoint slice
+
+The first implementation contains only:
+
+- `GET /api/v1/me`
+- `GET /api/v1/profiles/{handle}`
+- `GET /api/v1/spaces`
+- `GET /api/v1/spaces/{slug}`
+- `GET /api/v1/feed`
+- `GET /api/v1/posts/{post}`
+- `GET /api/v1/posts/{post}/comments`
+- `GET /api/v1/posts/{post}/media`
+- `GET /api/v1/notifications`
+
+The OpenAPI operations carry `x-lineweb-status: planned` until their routes,
+resources, authorization, throttling, and feature tests exist. Documentation
+must never make a planned endpoint look available.
+
+## Implementation acceptance gates
+
+Before changing an operation to `available`:
+
+1. The route requires Sanctum authentication, verified email, and its declared
+   token ability.
+2. A dedicated Resource or typed projection allowlists every response field.
+3. Feature tests cover public, private, hidden, non-member, mute, block,
+   moderation, deleted-target, and expired/revoked-token boundaries where they
+   apply.
+4. Cursor tests cover deterministic ordering, invalid reuse, maximum limits,
+   and no duplicate or missing records across pages.
+5. Throttle tests assert the JSON error envelope and retry headers.
+6. The OpenAPI example is generated from or checked against the actual response
+   shape.
+7. CI, dependency audits, and the public source hygiene check pass.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,657 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Lineweb Social API",
+    "version": "1.0.0-draft.1",
+    "description": "Contract-first draft for the authenticated read-only API. Every operation is planned and is not available until its x-lineweb-status changes to available.",
+    "license": {
+      "name": "GPL-3.0-or-later",
+      "identifier": "GPL-3.0-or-later"
+    }
+  },
+  "servers": [
+    {
+      "url": "/api/v1",
+      "description": "Current installation"
+    }
+  ],
+  "security": [
+    {
+      "BearerToken": []
+    }
+  ],
+  "paths": {
+    "/me": {
+      "get": {
+        "operationId": "getCurrentProfile",
+        "summary": "Return the authenticated member's safe profile",
+        "tags": ["Profiles"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "profile:read",
+        "responses": {
+          "200": {
+            "description": "Current profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/profiles/{handle}": {
+      "get": {
+        "operationId": "getProfile",
+        "summary": "Return a profile already visible to the member",
+        "tags": ["Profiles"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "profiles:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/ProfileHandle" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Visible profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/spaces": {
+      "get": {
+        "operationId": "listSpaces",
+        "summary": "List Spaces discoverable by the member",
+        "tags": ["Spaces"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "spaces:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/Limit" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Discoverable Spaces",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpaceCollection"
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/spaces/{slug}": {
+      "get": {
+        "operationId": "getSpace",
+        "summary": "Return one Space visible to the member",
+        "tags": ["Spaces"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "spaces:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/SpaceSlug" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Visible Space",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpaceResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/feed": {
+      "get": {
+        "operationId": "getFeed",
+        "summary": "Return the member's policy-filtered chronological feed",
+        "tags": ["Feed"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "feed:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/Limit" },
+          {
+            "name": "space",
+            "in": "query",
+            "required": false,
+            "description": "Optional visible Space slug.",
+            "schema": { "type": "string", "maxLength": 120 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chronological posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostCollection"
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/posts/{post}": {
+      "get": {
+        "operationId": "getPost",
+        "summary": "Return one visible post",
+        "tags": ["Posts"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "feed:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/PostId" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Visible post",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/posts/{post}/comments": {
+      "get": {
+        "operationId": "listPostComments",
+        "summary": "Return visible comments in chronological order",
+        "tags": ["Posts"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "feed:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/PostId" },
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/Limit" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chronological visible comments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentCollection"
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/posts/{post}/media": {
+      "get": {
+        "operationId": "getPostMedia",
+        "summary": "Return the authorized normalized post image",
+        "tags": ["Posts"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "feed:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/PostId" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Static normalized WebP image",
+            "headers": {
+              "Content-Type": {
+                "schema": { "type": "string", "const": "image/webp" }
+              },
+              "Cross-Origin-Resource-Policy": {
+                "schema": { "type": "string", "enum": ["same-site"] }
+              }
+            },
+            "content": {
+              "image/webp": {
+                "schema": { "type": "string", "contentEncoding": "binary" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "operationId": "listNotifications",
+        "summary": "Return the member's policy-resolved notifications",
+        "tags": ["Notifications"],
+        "x-lineweb-status": "planned",
+        "x-required-ability": "notifications:read",
+        "parameters": [
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/Limit" },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["all", "unread"],
+              "default": "all"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policy-resolved notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationCollection"
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthenticated" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Sanctum",
+        "description": "A time-limited token created from a verified, recently authenticated web session."
+      }
+    },
+    "parameters": {
+      "Cursor": {
+        "name": "cursor",
+        "in": "query",
+        "required": false,
+        "description": "Opaque cursor returned by the previous response.",
+        "schema": { "type": "string", "maxLength": 2048 }
+      },
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "default": 20
+        }
+      },
+      "ProfileHandle": {
+        "name": "handle",
+        "in": "path",
+        "required": true,
+        "schema": { "type": "string", "minLength": 1, "maxLength": 50 }
+      },
+      "SpaceSlug": {
+        "name": "slug",
+        "in": "path",
+        "required": true,
+        "schema": { "type": "string", "minLength": 1, "maxLength": 120 }
+      },
+      "PostId": {
+        "name": "post",
+        "in": "path",
+        "required": true,
+        "description": "Opaque post identifier.",
+        "schema": { "type": "string", "minLength": 1 }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Malformed input or a cursor used outside its original query.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Unauthenticated": {
+        "description": "Missing, expired, or revoked token.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "The verified member or token ability cannot perform this request.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The resource does not exist or is not visible to the member.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "The current rate limit was exceeded.",
+        "headers": {
+          "Retry-After": {
+            "schema": { "type": "integer", "minimum": 1 }
+          },
+          "RateLimit-Limit": {
+            "schema": { "type": "integer", "minimum": 1 }
+          },
+          "RateLimit-Remaining": {
+            "schema": { "type": "integer", "minimum": 0 }
+          },
+          "RateLimit-Reset": {
+            "schema": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["message", "code", "request_id"],
+        "properties": {
+          "message": { "type": "string" },
+          "code": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+          "request_id": { "type": "string", "format": "uuid" },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      },
+      "PaginationLinks": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["next"],
+        "properties": {
+          "next": { "type": ["string", "null"], "format": "uri-reference" }
+        }
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["next_cursor", "has_more", "limit"],
+        "properties": {
+          "next_cursor": { "type": ["string", "null"] },
+          "has_more": { "type": "boolean" },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 50 }
+        }
+      },
+      "ProfileSummary": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["handle", "name", "headline", "profile_visible"],
+        "properties": {
+          "handle": { "type": "string" },
+          "name": { "type": "string" },
+          "headline": { "type": ["string", "null"] },
+          "profile_visible": { "type": "boolean" }
+        }
+      },
+      "Profile": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["handle", "name", "headline", "bio", "location", "website_url", "member_since", "viewer"],
+        "properties": {
+          "handle": { "type": "string" },
+          "name": { "type": "string" },
+          "headline": { "type": ["string", "null"] },
+          "bio": { "type": ["string", "null"] },
+          "location": { "type": ["string", "null"] },
+          "website_url": { "type": ["string", "null"], "format": "uri" },
+          "member_since": { "type": "string", "format": "date" },
+          "viewer": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["is_self", "is_muted"],
+            "properties": {
+              "is_self": { "type": "boolean" },
+              "is_muted": { "type": "boolean" }
+            }
+          }
+        }
+      },
+      "ProfileResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["data"],
+        "properties": {
+          "data": { "$ref": "#/components/schemas/Profile" }
+        }
+      },
+      "Space": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["slug", "name", "description", "visibility", "member_count", "viewer"],
+        "properties": {
+          "slug": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": ["string", "null"] },
+          "visibility": { "type": "string", "enum": ["public", "private", "hidden"] },
+          "member_count": { "type": "integer", "minimum": 0 },
+          "viewer": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["is_member", "role", "can_manage"],
+            "properties": {
+              "is_member": { "type": "boolean" },
+              "role": { "type": ["string", "null"], "enum": ["owner", "moderator", "member", null] },
+              "can_manage": { "type": "boolean" }
+            }
+          }
+        }
+      },
+      "SpaceResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["data"],
+        "properties": {
+          "data": { "$ref": "#/components/schemas/Space" }
+        }
+      },
+      "SpaceCollection": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["data", "links", "meta"],
+        "properties": {
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Space" } },
+          "links": { "$ref": "#/components/schemas/PaginationLinks" },
+          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+        }
+      },
+      "Media": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["url", "alt", "width", "height", "mime_type"],
+        "properties": {
+          "url": { "type": "string", "format": "uri-reference" },
+          "alt": { "type": "string" },
+          "width": { "type": "integer", "minimum": 1, "maximum": 2048 },
+          "height": { "type": "integer", "minimum": 1, "maximum": 2048 },
+          "mime_type": { "type": "string", "const": "image/webp" }
+        }
+      },
+      "Comment": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "body", "published_at", "author", "viewer"],
+        "properties": {
+          "id": { "type": "string" },
+          "body": { "type": "string", "maxLength": 1000 },
+          "published_at": { "type": "string", "format": "date-time" },
+          "author": { "$ref": "#/components/schemas/ProfileSummary" },
+          "viewer": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["can_report", "has_reported"],
+            "properties": {
+              "can_report": { "type": "boolean" },
+              "has_reported": { "type": "boolean" }
+            }
+          }
+        }
+      },
+      "Post": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "body", "published_at", "media", "comments_count", "author", "space", "viewer"],
+        "properties": {
+          "id": { "type": "string" },
+          "body": { "type": "string", "maxLength": 2000 },
+          "published_at": { "type": "string", "format": "date-time" },
+          "media": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/Media" },
+              { "type": "null" }
+            ]
+          },
+          "comments_count": { "type": "integer", "minimum": 0 },
+          "author": { "$ref": "#/components/schemas/ProfileSummary" },
+          "space": { "$ref": "#/components/schemas/Space" },
+          "viewer": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["can_comment", "can_report", "has_reported"],
+            "properties": {
+              "can_comment": { "type": "boolean" },
+              "can_report": { "type": "boolean" },
+              "has_reported": { "type": "boolean" }
+            }
+          }
+        }
+      },
+      "PostResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["data"],
+        "properties": {
+          "data": { "$ref": "#/components/schemas/Post" }
+        }
+      },
+      "PostCollection": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["data", "links", "meta"],
+        "properties": {
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Post" } },
+          "links": { "$ref": "#/components/schemas/PaginationLinks" },
+          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+        }
+      },
+      "CommentCollection": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["data", "links", "meta"],
+        "properties": {
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Comment" } },
+          "links": { "$ref": "#/components/schemas/PaginationLinks" },
+          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+        }
+      },
+      "NotificationTarget": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type"],
+        "properties": {
+          "type": { "type": "string", "enum": ["post", "space_moderation"] },
+          "post_id": { "type": "string" },
+          "comment_id": { "type": "string" },
+          "space_slug": { "type": "string" }
+        }
+      },
+      "Notification": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "kind", "title", "description", "created_at", "read_at", "available", "target"],
+        "properties": {
+          "id": { "type": "string" },
+          "kind": { "type": "string", "enum": ["comment_reply", "space_moderation", "unavailable"] },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "read_at": { "type": ["string", "null"], "format": "date-time" },
+          "available": { "type": "boolean" },
+          "target": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/NotificationTarget" },
+              { "type": "null" }
+            ]
+          }
+        }
+      },
+      "NotificationCollection": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["data", "links", "meta"],
+        "properties": {
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Notification" } },
+          "links": { "$ref": "#/components/schemas/PaginationLinks" },
+          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+        }
+      }
+    }
+  }
+}

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -54,7 +54,9 @@ post policy on every request. The full contract is documented in
 
 ## Near-term contract work
 
-1. Add versioned API resources for native and decoupled clients, building on the stable web conversation, notification, and media projections.
+1. Implement the read-only resources in the contract-first
+   [`api-v1.md`](api-v1.md) and [`openapi.json`](openapi.json) draft, preserving
+   the stable web conversation, notification, and media policy boundaries.
 2. Define queued email and push delivery contracts without making the current web UI or database writes depend on an external transport.
 3. Implement and test the extension lifecycle before calling the manifest a plugin system.
 4. Define quotas and asynchronous processing before expanding post media to

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Unit;
+
+use JsonException;
+use Tests\TestCase;
+
+class ApiContractDocumentationTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    public function test_openapi_document_is_valid_json_with_the_expected_version_boundary(): void
+    {
+        $contract = $this->contract();
+
+        $this->assertSame('3.1.0', $contract['openapi']);
+        $this->assertSame('1.0.0-draft.1', $contract['info']['version']);
+        $this->assertSame('/api/v1', $contract['servers'][0]['url']);
+        $this->assertSame('http', $contract['components']['securitySchemes']['BearerToken']['type']);
+        $this->assertSame('bearer', $contract['components']['securitySchemes']['BearerToken']['scheme']);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function test_first_contract_is_explicitly_read_only_and_planned(): void
+    {
+        $contract = $this->contract();
+        $expectedPaths = [
+            '/feed',
+            '/me',
+            '/notifications',
+            '/posts/{post}',
+            '/posts/{post}/comments',
+            '/posts/{post}/media',
+            '/profiles/{handle}',
+            '/spaces',
+            '/spaces/{slug}',
+        ];
+        $paths = array_keys($contract['paths']);
+
+        sort($paths);
+
+        $this->assertSame($expectedPaths, $paths);
+
+        foreach ($contract['paths'] as $path => $pathItem) {
+            $this->assertSame(
+                ['get'],
+                array_keys($pathItem),
+                $path.' must remain read-only in the first contract slice.',
+            );
+            $this->assertSame('planned', $pathItem['get']['x-lineweb-status']);
+            $this->assertArrayNotHasKey('requestBody', $pathItem['get']);
+        }
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function test_every_operation_declares_ability_and_standard_security_failures(): void
+    {
+        $contract = $this->contract();
+        $allowedAbilities = [
+            'profile:read',
+            'profiles:read',
+            'spaces:read',
+            'feed:read',
+            'notifications:read',
+        ];
+
+        foreach ($contract['paths'] as $path => $pathItem) {
+            $operation = $pathItem['get'];
+
+            $this->assertContains($operation['x-required-ability'], $allowedAbilities);
+            $this->assertArrayHasKey('401', $operation['responses'], $path);
+            $this->assertArrayHasKey('403', $operation['responses'], $path);
+            $this->assertArrayHasKey('429', $operation['responses'], $path);
+        }
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function test_public_schemas_do_not_expose_sensitive_storage_or_account_fields(): void
+    {
+        $contract = $this->contract();
+        $schemas = $contract['components']['schemas'];
+
+        $this->assertSame(
+            ['handle', 'name', 'headline', 'bio', 'location', 'website_url', 'member_since', 'viewer'],
+            array_keys($schemas['Profile']['properties']),
+        );
+        $this->assertSame(
+            ['url', 'alt', 'width', 'height', 'mime_type'],
+            array_keys($schemas['Media']['properties']),
+        );
+        $this->assertSame(
+            ['id', 'kind', 'title', 'description', 'created_at', 'read_at', 'available', 'target'],
+            array_keys($schemas['Notification']['properties']),
+        );
+
+        foreach (['email', 'password', 'token', 'disk', 'path', 'checksum', 'data'] as $forbidden) {
+            $this->assertArrayNotHasKey($forbidden, $schemas['Profile']['properties']);
+            $this->assertArrayNotHasKey($forbidden, $schemas['Media']['properties']);
+            $this->assertArrayNotHasKey($forbidden, $schemas['Notification']['properties']);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws JsonException
+     */
+    private function contract(): array
+    {
+        $contents = file_get_contents(base_path('docs/openapi.json'));
+
+        $this->assertIsString($contents);
+
+        /** @var array<string, mixed> $contract */
+        $contract = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        return $contract;
+    }
+}


### PR DESCRIPTION
## Why

Native and decoupled clients need a stable boundary without inheriting internal Inertia props or raw model serialization. This defines that boundary before any endpoint becomes public.

## What changed

- documented the `/api/v1` compatibility, auth, token, pagination, throttling, CORS, error, and serialization rules
- added a read-only OpenAPI 3.1 draft with every operation clearly marked as planned
- added regression tests for the version boundary, read-only scope, abilities, security responses, and sensitive fields
- linked the contract from the README and platform roadmap

The draft deliberately avoids a password-to-token endpoint so the current passkey and two-factor protections are not bypassed.

## Validation

- `composer run ci:check` — 112 tests, 984 assertions
- Redocly OpenAPI lint — valid, no warnings
- `git diff --check`