### PR TITLE
Expose policy-safe profile API reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable project changes will be documented here.
   authentication, verified accounts, `profile:read`, expiring token management,
   stable request IDs/errors, explicit profile serialization, and lifecycle
   revocation.
+- Policy-safe `GET /api/v1/profiles/{handle}` access under the separate
+  `profiles:read` ability, preserving direct-link visibility, shared-Space
+  privacy, mute state, and mutual block boundaries.
 - Optional single-image post attachments with required alternative text,
   private policy-protected delivery, bounded processing, and static WebP
   normalization that discards original metadata and filenames.

--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ on a private disk, and authorized through their parent post. See
 [`docs/media.md`](docs/media.md) for the limits, lifecycle, and storage contract.
 
 The authenticated native/decoupled API is being developed contract-first. Its
-first available operation, `GET /api/v1/me`, uses expiring limited bearer
-tokens created from recently confirmed Security settings. The remaining
-read-only draft fixes cursor pagination, throttling, CORS, stable errors, and
-policy-safe resources before more endpoints are exposed. See
+first available operations return the current safe profile and profiles already
+visible to that member. They use expiring, explicitly scoped bearer tokens
+created from recently confirmed Security settings. The remaining read-only
+draft fixes cursor pagination, throttling, CORS, stable errors, and policy-safe
+resources before more endpoints are exposed. See
 [`docs/api-v1.md`](docs/api-v1.md) and the machine-readable
 [`docs/openapi.json`](docs/openapi.json).
 

--- a/app/Http/Controllers/Api/V1/ProfileController.php
+++ b/app/Http/Controllers/Api/V1/ProfileController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\ProfileResource;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class ProfileController extends Controller
+{
+    public function __invoke(User $profile): ProfileResource
+    {
+        Gate::authorize('view', $profile);
+
+        return new ProfileResource($profile);
+    }
+}

--- a/app/Http/Controllers/Settings/ApiTokenController.php
+++ b/app/Http/Controllers/Settings/ApiTokenController.php
@@ -12,8 +12,6 @@ use Inertia\Inertia;
 
 class ApiTokenController extends Controller
 {
-    private const ABILITIES = ['profile:read'];
-
     private const MAX_ACTIVE_TOKENS = 10;
 
     public function store(StoreApiTokenRequest $request): RedirectResponse
@@ -37,7 +35,7 @@ class ApiTokenController extends Controller
         $expiresAt = now()->addDays(30);
         $newToken = $user->createToken(
             $request->string('name')->toString(),
-            self::ABILITIES,
+            $request->array('abilities'),
             $expiresAt,
         );
 

--- a/app/Http/Requests/Settings/StoreApiTokenRequest.php
+++ b/app/Http/Requests/Settings/StoreApiTokenRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Settings;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreApiTokenRequest extends FormRequest
 {
@@ -18,6 +19,13 @@ class StoreApiTokenRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'min:2', 'max:80'],
+            'abilities' => ['required', 'array', 'min:1', 'max:2'],
+            'abilities.*' => [
+                'required',
+                'string',
+                'distinct',
+                Rule::in(['profile:read', 'profiles:read']),
+            ],
         ];
     }
 }

--- a/app/Http/Resources/Api/V1/ProfileResource.php
+++ b/app/Http/Resources/Api/V1/ProfileResource.php
@@ -14,6 +14,8 @@ class ProfileResource extends JsonResource
     {
         /** @var User $profile */
         $profile = $this->resource;
+        /** @var User $viewer */
+        $viewer = $request->user();
 
         return [
             'handle' => $profile->handle,
@@ -24,8 +26,8 @@ class ProfileResource extends JsonResource
             'website_url' => $profile->website_url,
             'member_since' => $profile->created_at?->toDateString(),
             'viewer' => [
-                'is_self' => true,
-                'is_muted' => false,
+                'is_self' => $viewer->is($profile),
+                'is_muted' => ! $viewer->is($profile) && $viewer->hasMuted($profile),
             ],
         ];
     }

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -3,8 +3,9 @@
 ## Status
 
 This document defines the first public contract for authenticated native and
-decoupled clients. `GET /api/v1/me` is the first available operation; the other
-endpoints in `openapi.json` remain **planned, not yet implemented**.
+decoupled clients. `GET /api/v1/me` and `GET /api/v1/profiles/{handle}` are
+available; the other endpoints in `openapi.json` remain **planned, not yet
+implemented**.
 Contract-first development keeps client expectations separate from the current
 Inertia view models and prevents accidental exposure of raw database records.
 
@@ -208,7 +209,7 @@ Public or long-lived signed media URLs are intentionally outside this draft.
 The read-only API roadmap contains:
 
 - `GET /api/v1/me` — available
-- `GET /api/v1/profiles/{handle}`
+- `GET /api/v1/profiles/{handle}` — available
 - `GET /api/v1/spaces`
 - `GET /api/v1/spaces/{slug}`
 - `GET /api/v1/feed`
@@ -218,9 +219,9 @@ The read-only API roadmap contains:
 - `GET /api/v1/notifications`
 
 OpenAPI operations carry `x-lineweb-status: planned` until their routes,
-resources, authorization, throttling, and feature tests exist. Only `/me`
-currently carries `x-lineweb-status: available`. Documentation must never make
-a planned endpoint look available.
+resources, authorization, throttling, and feature tests exist. Only `/me` and
+`/profiles/{handle}` currently carry `x-lineweb-status: available`.
+Documentation must never make a planned endpoint look available.
 
 ## Implementation acceptance gates
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -50,7 +50,7 @@
         "operationId": "getProfile",
         "summary": "Return a profile already visible to the member",
         "tags": ["Profiles"],
-        "x-lineweb-status": "planned",
+        "x-lineweb-status": "available",
         "x-required-ability": "profiles:read",
         "parameters": [
           { "$ref": "#/components/parameters/ProfileHandle" }

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -54,8 +54,8 @@ post policy on every request. The full contract is documented in
 
 ## Near-term contract work
 
-1. Expand the authenticated read-only API beyond the available `/api/v1/me`
-   resource using the contract-first [`api-v1.md`](api-v1.md) and
+1. Expand the authenticated read-only API beyond the available profile
+   resources using the contract-first [`api-v1.md`](api-v1.md) and
    [`openapi.json`](openapi.json) draft, preserving the stable web conversation,
    notification, and media policy boundaries.
 2. Define queued email and push delivery contracts without making the current web UI or database writes depend on an external transport.

--- a/resources/js/components/manage-api-tokens.tsx
+++ b/resources/js/components/manage-api-tokens.tsx
@@ -127,8 +127,8 @@ export default function ManageApiTokens({ apiTokens }: Props) {
                 className="rounded-2xl border border-border bg-card p-4 sm:p-5"
             >
                 {({ errors, processing }) => (
-                    <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
-                        <div className="grid gap-2">
+                    <div className="grid gap-5">
+                        <div className="grid gap-2 sm:max-w-xl">
                             <Label htmlFor="api-token-name">Token name</Label>
                             <Input
                                 id="api-token-name"
@@ -140,15 +140,63 @@ export default function ManageApiTokens({ apiTokens }: Props) {
                                 required
                             />
                             <InputError message={errors.name} />
-                            <p className="text-xs text-muted-foreground">
-                                Access: your safe profile only. Tokens expire
-                                after 30 days.
-                            </p>
                         </div>
-                        <Button type="submit" disabled={processing}>
-                            <KeyRound />
-                            {processing ? 'Creating...' : 'Create token'}
-                        </Button>
+
+                        <fieldset className="grid gap-3">
+                            <legend className="text-sm font-medium">
+                                Token access
+                            </legend>
+                            <input
+                                type="hidden"
+                                name="abilities[]"
+                                value="profile:read"
+                            />
+                            <label className="flex items-start gap-3 rounded-xl border border-border p-3">
+                                <span
+                                    aria-hidden="true"
+                                    className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary text-primary-foreground opacity-60"
+                                >
+                                    <Check className="size-3" />
+                                </span>
+                                <span>
+                                    <span className="block text-sm font-medium">
+                                        Own safe profile
+                                    </span>
+                                    <span className="block text-xs text-muted-foreground">
+                                        Required for every token.
+                                    </span>
+                                </span>
+                            </label>
+                            <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border p-3 transition-colors hover:bg-muted/50">
+                                <input
+                                    type="checkbox"
+                                    name="abilities[]"
+                                    value="profiles:read"
+                                    className="mt-0.5 size-4 shrink-0 accent-primary"
+                                />
+                                <span>
+                                    <span className="block text-sm font-medium">
+                                        Visible member profiles
+                                    </span>
+                                    <span className="block text-xs text-muted-foreground">
+                                        Read only profiles already allowed by
+                                        their privacy and safety settings.
+                                    </span>
+                                </span>
+                            </label>
+                            <InputError message={errors.abilities} />
+                        </fieldset>
+
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <p className="text-xs text-muted-foreground">
+                                Tokens expire after 30 days. Grant only the
+                                access this client needs.
+                            </p>
+                            <Button type="submit" disabled={processing}>
+                                <KeyRound />
+                                {processing ? 'Creating...' : 'Create token'}
+                            </Button>
+                        </div>
                     </div>
                 )}
             </Form>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\V1\CurrentProfileController;
+use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Middleware\AssignApiRequestId;
 use App\Http\Middleware\RequireBearerAccessToken;
 use Illuminate\Support\Facades\Route;
@@ -11,9 +12,13 @@ Route::prefix('v1')
         'auth:sanctum',
         RequireBearerAccessToken::class,
         'verified',
-        'abilities:profile:read',
         'throttle:api-read',
     ])
     ->group(function (): void {
-        Route::get('me', CurrentProfileController::class)->name('api.v1.me');
+        Route::get('me', CurrentProfileController::class)
+            ->middleware('abilities:profile:read')
+            ->name('api.v1.me');
+        Route::get('profiles/{profile:handle}', ProfileController::class)
+            ->middleware('abilities:profiles:read')
+            ->name('api.v1.profiles.show');
     });

--- a/tests/Feature/Api/VisibleProfileTest.php
+++ b/tests/Feature/Api/VisibleProfileTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Enums\ProfileVisibility;
+use App\Enums\UserRelationshipType;
+use App\Models\Space;
+use App\Models\User;
+use App\Models\UserRelationship;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class VisibleProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_profile_uses_the_safe_contract_and_viewer_relationship_state(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create([
+            'name' => 'Visible Member',
+            'headline' => 'Community builder',
+            'bio' => 'A safe public bio.',
+            'location' => 'Thessaloniki',
+            'website_url' => 'https://www.lineweb.gr',
+            'profile_visibility' => ProfileVisibility::Public,
+        ]);
+        UserRelationship::query()->create([
+            'actor_id' => $viewer->getKey(),
+            'target_id' => $profile->getKey(),
+            'type' => UserRelationshipType::Mute,
+        ]);
+
+        $response = $this->withToken($this->token($viewer, ['profiles:read']))
+            ->getJson(route('api.v1.profiles.show', $profile));
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.handle', $profile->handle)
+            ->assertJsonPath('data.name', 'Visible Member')
+            ->assertJsonPath('data.viewer.is_self', false)
+            ->assertJsonPath('data.viewer.is_muted', true)
+            ->assertJsonMissingPath('data.email')
+            ->assertJsonMissingPath('data.profile_visibility')
+            ->assertJsonMissingPath('data.is_discoverable');
+
+        $this->assertSame(
+            ['handle', 'name', 'headline', 'bio', 'location', 'website_url', 'member_since', 'viewer'],
+            array_keys($response->json('data')),
+        );
+    }
+
+    public function test_discovery_opt_out_does_not_hide_an_otherwise_public_direct_profile(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create([
+            'profile_visibility' => ProfileVisibility::Public,
+            'is_discoverable' => false,
+        ]);
+
+        $this->withToken($this->token($viewer, ['profiles:read']))
+            ->getJson(route('api.v1.profiles.show', $profile))
+            ->assertOk();
+    }
+
+    public function test_private_and_unshared_member_profiles_are_forbidden(): void
+    {
+        $viewer = User::factory()->create();
+        $private = User::factory()->create(['profile_visibility' => ProfileVisibility::Private]);
+        $members = User::factory()->create(['profile_visibility' => ProfileVisibility::Members]);
+        $plainTextToken = $this->token($viewer, ['profiles:read']);
+
+        foreach ([$private, $members] as $profile) {
+            $this->withToken($plainTextToken)
+                ->getJson(route('api.v1.profiles.show', $profile))
+                ->assertForbidden()
+                ->assertJsonPath('code', 'forbidden');
+        }
+    }
+
+    public function test_members_profile_is_visible_after_a_shared_space_exists(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create(['profile_visibility' => ProfileVisibility::Members]);
+        $space = Space::factory()->private()->create();
+        $space->addMember($viewer);
+        $space->addMember($profile);
+
+        $this->withToken($this->token($viewer, ['profiles:read']))
+            ->getJson(route('api.v1.profiles.show', $profile))
+            ->assertOk()
+            ->assertJsonPath('data.handle', $profile->handle);
+    }
+
+    public function test_a_block_in_either_direction_denies_profile_access(): void
+    {
+        $viewer = User::factory()->create(['profile_visibility' => ProfileVisibility::Public]);
+        $profile = User::factory()->create(['profile_visibility' => ProfileVisibility::Public]);
+        $plainTextToken = $this->token($viewer, ['profiles:read']);
+
+        foreach ([
+            [$viewer, $profile],
+            [$profile, $viewer],
+        ] as [$actor, $target]) {
+            UserRelationship::query()->create([
+                'actor_id' => $actor->getKey(),
+                'target_id' => $target->getKey(),
+                'type' => UserRelationshipType::Block,
+            ]);
+
+            $this->withToken($plainTextToken)
+                ->getJson(route('api.v1.profiles.show', $profile))
+                ->assertForbidden();
+
+            UserRelationship::query()->delete();
+        }
+    }
+
+    public function test_self_profile_is_available_through_the_profiles_scope(): void
+    {
+        $viewer = User::factory()->create(['profile_visibility' => ProfileVisibility::Private]);
+
+        $this->withToken($this->token($viewer, ['profiles:read']))
+            ->getJson(route('api.v1.profiles.show', $viewer))
+            ->assertOk()
+            ->assertJsonPath('data.viewer.is_self', true)
+            ->assertJsonPath('data.viewer.is_muted', false);
+    }
+
+    public function test_missing_profile_uses_the_stable_not_found_envelope(): void
+    {
+        $viewer = User::factory()->create();
+
+        $response = $this->withToken($this->token($viewer, ['profiles:read']))
+            ->getJson('/api/v1/profiles/not-a-real-handle');
+
+        $response
+            ->assertNotFound()
+            ->assertJsonPath('code', 'not_found')
+            ->assertJsonPath('message', 'The requested resource was not found.');
+        $this->assertTrue(Str::isUuid($response->json('request_id')));
+    }
+
+    public function test_profile_endpoint_requires_its_declared_ability(): void
+    {
+        $viewer = User::factory()->create();
+        $profile = User::factory()->create(['profile_visibility' => ProfileVisibility::Public]);
+
+        $this->withToken($this->token($viewer, ['profile:read']))
+            ->getJson(route('api.v1.profiles.show', $profile))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+    }
+
+    /** @param list<string> $abilities */
+    private function token(User $user, array $abilities): string
+    {
+        return $user->createToken('API test', $abilities, now()->addDays(30))->plainTextToken;
+    }
+}

--- a/tests/Feature/Settings/ApiTokenManagementTest.php
+++ b/tests/Feature/Settings/ApiTokenManagementTest.php
@@ -57,7 +57,10 @@ class ApiTokenManagementTest extends TestCase
         $response = $this->actingAs($user)
             ->withSession(['auth.password_confirmed_at' => time()])
             ->from(route('security.edit'))
-            ->post(route('api-tokens.store'), ['name' => '  My phone  ']);
+            ->post(route('api-tokens.store'), [
+                'name' => '  My phone  ',
+                'abilities' => ['profile:read', 'profiles:read'],
+            ]);
 
         $response
             ->assertSessionHasNoErrors()
@@ -67,7 +70,7 @@ class ApiTokenManagementTest extends TestCase
         $flash = $response->getSession()->get(SessionKey::FLASH_DATA);
 
         $this->assertSame('My phone', $token->name);
-        $this->assertSame(['profile:read'], $token->abilities);
+        $this->assertSame(['profile:read', 'profiles:read'], $token->abilities);
         $this->assertSame(now()->addDays(30)->timestamp, $token->expires_at?->timestamp);
         $this->assertIsArray($flash);
         $this->assertSame('My phone', $flash['apiToken']['name']);
@@ -84,7 +87,10 @@ class ApiTokenManagementTest extends TestCase
 
         $this->actingAs($user)
             ->withSession(['auth.password_confirmed_at' => time()])
-            ->post(route('api-tokens.store'), ['name' => ' '])
+            ->post(route('api-tokens.store'), [
+                'name' => ' ',
+                'abilities' => ['profile:read'],
+            ])
             ->assertSessionHasErrors('name');
 
         for ($token = 1; $token <= 10; $token++) {
@@ -97,10 +103,35 @@ class ApiTokenManagementTest extends TestCase
 
         $this->actingAs($user)
             ->withSession(['auth.password_confirmed_at' => time()])
-            ->post(route('api-tokens.store'), ['name' => 'One too many'])
+            ->post(route('api-tokens.store'), [
+                'name' => 'One too many',
+                'abilities' => ['profile:read'],
+            ])
             ->assertSessionHasErrors('name');
 
         $this->assertCount(10, $user->tokens()->get());
+    }
+
+    public function test_token_abilities_are_required_and_limited_to_the_public_allowlist(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->post(route('api-tokens.store'), [
+                'name' => 'Unsafe client',
+                'abilities' => ['*'],
+            ])
+            ->assertSessionHasErrors('abilities.0');
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->post(route('api-tokens.store'), [
+                'name' => 'Missing abilities',
+            ])
+            ->assertSessionHasErrors('abilities');
+
+        $this->assertDatabaseCount('personal_access_tokens', 0);
     }
 
     public function test_member_can_revoke_one_or_all_of_their_tokens_only(): void

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -24,7 +24,7 @@ class ApiContractDocumentationTest extends TestCase
     /**
      * @throws JsonException
      */
-    public function test_first_contract_is_read_only_and_only_me_is_available(): void
+    public function test_first_contract_is_read_only_and_only_implemented_profiles_are_available(): void
     {
         $contract = $this->contract();
         $expectedPaths = [
@@ -51,7 +51,7 @@ class ApiContractDocumentationTest extends TestCase
                 $path.' must remain read-only in the first contract slice.',
             );
             $this->assertSame(
-                $path === '/me' ? 'available' : 'planned',
+                in_array($path, ['/me', '/profiles/{handle}'], true) ? 'available' : 'planned',
                 $pathItem['get']['x-lineweb-status'],
             );
             $this->assertArrayNotHasKey('requestBody', $pathItem['get']);


### PR DESCRIPTION
Lets trusted clients read profiles without bypassing the privacy and safety rules already used by the web application.

- Adds GET /api/v1/profiles/{handle} under the separate profiles:read ability
- Reuses the User view policy for public, shared-Space, private, and mutual-block boundaries
- Keeps discovery opt-out separate from direct-link visibility and returns only the explicit safe Profile resource
- Adds least-privilege scope selection to Security settings and rejects unknown or wildcard abilities
- Marks only the implemented profile operation available in OpenAPI and public docs

Validated with:
- composer run ci:check (135 tests, 1,240 assertions)
- npm run build
- Redocly OpenAPI lint
- Desktop and 390px mobile browser QA for scope selection, token lifecycle, overflow, and console output