### PR TITLE
Add read-only Spaces API

### DIFF
--- a/app/Http/Controllers/Api/V1/SpaceController.php
+++ b/app/Http/Controllers/Api/V1/SpaceController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\SpaceResource;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+class SpaceController extends Controller
+{
+    public function __invoke(Request $request, Space $space): SpaceResource
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        Gate::authorize('view', $space);
+
+        $space->loadCount('members');
+        $space->setAttribute('is_member', $space->hasMember($user));
+        $space->setAttribute('current_role', $space->roleFor($user)?->value);
+
+        return new SpaceResource($space);
+    }
+}

--- a/app/Http/Controllers/Api/V1/SpaceIndexController.php
+++ b/app/Http/Controllers/Api/V1/SpaceIndexController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\SpaceResource;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class SpaceIndexController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        /** @var array{limit?: int, cursor?: string} $validated */
+        $validated = $request->validate([
+            'cursor' => ['sometimes', 'string', 'max:2048'],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:50'],
+        ]);
+        $limit = (int) ($validated['limit'] ?? 20);
+
+        $paginator = Space::query()
+            ->discoverableBy($user)
+            ->addSelect([
+                'current_role' => DB::table('space_members')
+                    ->select('role')
+                    ->whereColumn('space_members.space_id', 'spaces.id')
+                    ->where('space_members.user_id', $user->getKey())
+                    ->limit(1),
+            ])
+            ->withExists([
+                'members as is_member' => fn (Builder $query) => $query->whereKey($user->getKey()),
+            ])
+            ->withCount('members')
+            ->orderBy('name')
+            ->orderBy('id')
+            ->cursorPaginate($limit)
+            ->withQueryString();
+
+        return response()->json([
+            'data' => $paginator->getCollection()
+                ->map(fn (Space $space): array => (new SpaceResource($space))->toArray($request))
+                ->values()
+                ->all(),
+            'links' => [
+                'next' => $paginator->nextPageUrl(),
+            ],
+            'meta' => [
+                'next_cursor' => $paginator->nextCursor()?->encode(),
+                'has_more' => $paginator->hasMorePages(),
+                'limit' => $limit,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Settings/StoreApiTokenRequest.php
+++ b/app/Http/Requests/Settings/StoreApiTokenRequest.php
@@ -19,12 +19,12 @@ class StoreApiTokenRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'min:2', 'max:80'],
-            'abilities' => ['required', 'array', 'min:1', 'max:2'],
+            'abilities' => ['required', 'array', 'min:1', 'max:3'],
             'abilities.*' => [
                 'required',
                 'string',
                 'distinct',
-                Rule::in(['profile:read', 'profiles:read']),
+                Rule::in(['profile:read', 'profiles:read', 'spaces:read']),
             ],
         ];
     }

--- a/app/Http/Resources/Api/V1/SpaceResource.php
+++ b/app/Http/Resources/Api/V1/SpaceResource.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Enums\SpaceRole;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Space */
+class SpaceResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        /** @var Space $space */
+        $space = $this->resource;
+        /** @var User $viewer */
+        $viewer = $request->user();
+        $role = $this->viewerRole($space, $viewer);
+
+        return [
+            'slug' => $space->slug,
+            'name' => $space->name,
+            'description' => $space->description,
+            'visibility' => $space->visibility->value,
+            'member_count' => (int) ($space->members_count ?? 0),
+            'viewer' => [
+                'is_member' => (bool) ($space->is_member ?? $space->hasMember($viewer)),
+                'role' => $role?->value,
+                'can_manage' => in_array($role, [SpaceRole::Owner, SpaceRole::Moderator], true),
+            ],
+        ];
+    }
+
+    private function viewerRole(Space $space, User $viewer): ?SpaceRole
+    {
+        $role = $space->current_role ?? null;
+
+        if (is_string($role)) {
+            return SpaceRole::tryFrom($role);
+        }
+
+        return $space->roleFor($viewer);
+    }
+}

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -3,9 +3,9 @@
 ## Status
 
 This document defines the first public contract for authenticated native and
-decoupled clients. `GET /api/v1/me` and `GET /api/v1/profiles/{handle}` are
-available; the other endpoints in `openapi.json` remain **planned, not yet
-implemented**.
+decoupled clients. `GET /api/v1/me`, `GET /api/v1/profiles/{handle}`,
+`GET /api/v1/spaces`, and `GET /api/v1/spaces/{slug}` are available; the
+other endpoints in `openapi.json` remain **planned, not yet implemented**.
 Contract-first development keeps client expectations separate from the current
 Inertia view models and prevents accidental exposure of raw database records.
 
@@ -210,8 +210,8 @@ The read-only API roadmap contains:
 
 - `GET /api/v1/me` — available
 - `GET /api/v1/profiles/{handle}` — available
-- `GET /api/v1/spaces`
-- `GET /api/v1/spaces/{slug}`
+- `GET /api/v1/spaces` — available
+- `GET /api/v1/spaces/{slug}` — available
 - `GET /api/v1/feed`
 - `GET /api/v1/posts/{post}`
 - `GET /api/v1/posts/{post}/comments`
@@ -220,7 +220,8 @@ The read-only API roadmap contains:
 
 OpenAPI operations carry `x-lineweb-status: planned` until their routes,
 resources, authorization, throttling, and feature tests exist. Only `/me` and
-`/profiles/{handle}` currently carry `x-lineweb-status: available`.
+`/profiles/{handle}`, `/spaces`, and `/spaces/{slug}` currently carry
+`x-lineweb-status: available`.
 Documentation must never make a planned endpoint look available.
 
 ## Implementation acceptance gates

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,7 +78,7 @@
         "operationId": "listSpaces",
         "summary": "List Spaces discoverable by the member",
         "tags": ["Spaces"],
-        "x-lineweb-status": "planned",
+        "x-lineweb-status": "available",
         "x-required-ability": "spaces:read",
         "parameters": [
           { "$ref": "#/components/parameters/Cursor" },
@@ -107,7 +107,7 @@
         "operationId": "getSpace",
         "summary": "Return one Space visible to the member",
         "tags": ["Spaces"],
-        "x-lineweb-status": "planned",
+        "x-lineweb-status": "available",
         "x-required-ability": "spaces:read",
         "parameters": [
           { "$ref": "#/components/parameters/SpaceSlug" }

--- a/resources/js/components/manage-api-tokens.tsx
+++ b/resources/js/components/manage-api-tokens.tsx
@@ -184,6 +184,23 @@ export default function ManageApiTokens({ apiTokens }: Props) {
                                     </span>
                                 </span>
                             </label>
+                            <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border p-3 transition-colors hover:bg-muted/50">
+                                <input
+                                    type="checkbox"
+                                    name="abilities[]"
+                                    value="spaces:read"
+                                    className="mt-0.5 size-4 shrink-0 accent-primary"
+                                />
+                                <span>
+                                    <span className="block text-sm font-medium">
+                                        Discoverable Spaces
+                                    </span>
+                                    <span className="block text-xs text-muted-foreground">
+                                        Read public Spaces and private or hidden
+                                        Spaces where you are already a member.
+                                    </span>
+                                </span>
+                            </label>
                             <InputError message={errors.abilities} />
                         </fieldset>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\Api\V1\CurrentProfileController;
 use App\Http\Controllers\Api\V1\ProfileController;
+use App\Http\Controllers\Api\V1\SpaceController;
+use App\Http\Controllers\Api\V1\SpaceIndexController;
 use App\Http\Middleware\AssignApiRequestId;
 use App\Http\Middleware\RequireBearerAccessToken;
 use Illuminate\Support\Facades\Route;
@@ -21,4 +23,10 @@ Route::prefix('v1')
         Route::get('profiles/{profile:handle}', ProfileController::class)
             ->middleware('abilities:profiles:read')
             ->name('api.v1.profiles.show');
+        Route::get('spaces', SpaceIndexController::class)
+            ->middleware('abilities:spaces:read')
+            ->name('api.v1.spaces.index');
+        Route::get('spaces/{space:slug}', SpaceController::class)
+            ->middleware('abilities:spaces:read')
+            ->name('api.v1.spaces.show');
     });

--- a/tests/Feature/Api/VisibleSpaceTest.php
+++ b/tests/Feature/Api/VisibleSpaceTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Enums\SpaceRole;
+use App\Enums\UserRelationshipType;
+use App\Models\Space;
+use App\Models\User;
+use App\Models\UserRelationship;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VisibleSpaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_spaces_index_returns_only_discoverable_spaces_with_viewer_state_and_cursor_pagination(): void
+    {
+        $viewer = User::factory()->create();
+        $public = Space::factory()->create([
+            'name' => 'Alpha Public',
+            'slug' => 'alpha-public',
+            'description' => 'Open community space.',
+        ]);
+        $privateMember = Space::factory()->private()->create([
+            'name' => 'Beta Private',
+            'slug' => 'beta-private',
+        ]);
+        $hiddenModerator = Space::factory()->hidden()->create([
+            'name' => 'Gamma Hidden',
+            'slug' => 'gamma-hidden',
+        ]);
+        $inaccessiblePrivate = Space::factory()->private()->create([
+            'name' => 'Hidden From Viewer',
+            'slug' => 'hidden-from-viewer',
+        ]);
+        $inaccessibleHidden = Space::factory()->hidden()->create([
+            'name' => 'Invisible Circle',
+            'slug' => 'invisible-circle',
+        ]);
+
+        $privateMember->addMember($viewer);
+        $hiddenModerator->addMember($viewer, SpaceRole::Moderator);
+
+        $response = $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.spaces.index', ['limit' => 2]));
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('meta.limit', 2)
+            ->assertJsonPath('meta.has_more', true)
+            ->assertJsonPath('links.next', fn (?string $url): bool => is_string($url) && str_contains($url, 'cursor='))
+            ->assertJsonPath('data.0.slug', $public->slug)
+            ->assertJsonPath('data.0.member_count', 1)
+            ->assertJsonPath('data.0.viewer.is_member', false)
+            ->assertJsonPath('data.0.viewer.role', null)
+            ->assertJsonPath('data.0.viewer.can_manage', false)
+            ->assertJsonPath('data.1.slug', $privateMember->slug)
+            ->assertJsonPath('data.1.viewer.is_member', true)
+            ->assertJsonPath('data.1.viewer.role', 'member')
+            ->assertJsonPath('data.1.viewer.can_manage', false)
+            ->assertJsonMissing(['slug' => $inaccessiblePrivate->slug])
+            ->assertJsonMissing(['slug' => $inaccessibleHidden->slug]);
+
+        $nextResponse = $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.spaces.index', [
+                'limit' => 2,
+                'cursor' => $response->json('meta.next_cursor'),
+            ]));
+
+        $nextResponse
+            ->assertOk()
+            ->assertJsonPath('meta.has_more', false)
+            ->assertJsonPath('links.next', null)
+            ->assertJsonPath('data.0.slug', $hiddenModerator->slug)
+            ->assertJsonPath('data.0.viewer.role', 'moderator')
+            ->assertJsonPath('data.0.viewer.can_manage', true);
+
+        $this->assertSame(
+            ['slug', 'name', 'description', 'visibility', 'member_count', 'viewer'],
+            array_keys($response->json('data.0')),
+        );
+    }
+
+    public function test_space_detail_uses_the_same_visibility_policy_as_the_web_surface(): void
+    {
+        $viewer = User::factory()->create();
+        $public = Space::factory()->create(['slug' => 'open-space']);
+        $private = Space::factory()->private()->create(['slug' => 'private-space']);
+        $hidden = Space::factory()->hidden()->create(['slug' => 'hidden-space']);
+        $hidden->addMember($viewer, SpaceRole::Owner);
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.spaces.show', $public))
+            ->assertOk()
+            ->assertJsonPath('data.slug', $public->slug)
+            ->assertJsonPath('data.viewer.is_member', false);
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.spaces.show', $private))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.spaces.show', $hidden))
+            ->assertOk()
+            ->assertJsonPath('data.slug', $hidden->slug)
+            ->assertJsonPath('data.visibility', 'hidden')
+            ->assertJsonPath('data.viewer.role', 'owner')
+            ->assertJsonPath('data.viewer.can_manage', true);
+    }
+
+    public function test_block_relationship_does_not_grant_private_space_access_or_expose_member_records(): void
+    {
+        $viewer = User::factory()->create();
+        $owner = User::factory()->create();
+        $space = Space::factory()->private()->create([
+            'owner_id' => $owner->getKey(),
+            'slug' => 'blocked-private-space',
+        ]);
+
+        UserRelationship::query()->create([
+            'actor_id' => $owner->getKey(),
+            'target_id' => $viewer->getKey(),
+            'type' => UserRelationshipType::Block,
+        ]);
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.spaces.index'))
+            ->assertOk()
+            ->assertJsonMissing(['slug' => $space->slug])
+            ->assertJsonMissingPath('data.0.owner')
+            ->assertJsonMissingPath('data.0.members');
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.spaces.show', $space))
+            ->assertForbidden();
+    }
+
+    public function test_space_endpoints_require_the_declared_spaces_read_ability(): void
+    {
+        $viewer = User::factory()->create();
+        $space = Space::factory()->create();
+        $plainTextToken = $this->token($viewer, ['profile:read']);
+
+        $this->withToken($plainTextToken)
+            ->getJson(route('api.v1.spaces.index'))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+
+        $this->withToken($plainTextToken)
+            ->getJson(route('api.v1.spaces.show', $space))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+    }
+
+    /** @param list<string> $abilities */
+    private function token(User $user, array $abilities = ['spaces:read']): string
+    {
+        return $user->createToken('Spaces API test', $abilities, now()->addDays(30))->plainTextToken;
+    }
+}

--- a/tests/Feature/Settings/ApiTokenManagementTest.php
+++ b/tests/Feature/Settings/ApiTokenManagementTest.php
@@ -59,7 +59,7 @@ class ApiTokenManagementTest extends TestCase
             ->from(route('security.edit'))
             ->post(route('api-tokens.store'), [
                 'name' => '  My phone  ',
-                'abilities' => ['profile:read', 'profiles:read'],
+                'abilities' => ['profile:read', 'profiles:read', 'spaces:read'],
             ]);
 
         $response
@@ -70,7 +70,7 @@ class ApiTokenManagementTest extends TestCase
         $flash = $response->getSession()->get(SessionKey::FLASH_DATA);
 
         $this->assertSame('My phone', $token->name);
-        $this->assertSame(['profile:read', 'profiles:read'], $token->abilities);
+        $this->assertSame(['profile:read', 'profiles:read', 'spaces:read'], $token->abilities);
         $this->assertSame(now()->addDays(30)->timestamp, $token->expires_at?->timestamp);
         $this->assertIsArray($flash);
         $this->assertSame('My phone', $flash['apiToken']['name']);

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -24,7 +24,7 @@ class ApiContractDocumentationTest extends TestCase
     /**
      * @throws JsonException
      */
-    public function test_first_contract_is_read_only_and_only_implemented_profiles_are_available(): void
+    public function test_first_contract_is_read_only_and_only_implemented_read_operations_are_available(): void
     {
         $contract = $this->contract();
         $expectedPaths = [
@@ -51,7 +51,7 @@ class ApiContractDocumentationTest extends TestCase
                 $path.' must remain read-only in the first contract slice.',
             );
             $this->assertSame(
-                in_array($path, ['/me', '/profiles/{handle}'], true) ? 'available' : 'planned',
+                in_array($path, ['/me', '/profiles/{handle}', '/spaces', '/spaces/{slug}'], true) ? 'available' : 'planned',
                 $pathItem['get']['x-lineweb-status'],
             );
             $this->assertArrayNotHasKey('requestBody', $pathItem['get']);
@@ -108,9 +108,14 @@ class ApiContractDocumentationTest extends TestCase
             ['id', 'kind', 'title', 'description', 'created_at', 'read_at', 'available', 'target'],
             array_keys($schemas['Notification']['properties']),
         );
+        $this->assertSame(
+            ['slug', 'name', 'description', 'visibility', 'member_count', 'viewer'],
+            array_keys($schemas['Space']['properties']),
+        );
 
         foreach (['email', 'password', 'token', 'disk', 'path', 'checksum', 'data'] as $forbidden) {
             $this->assertArrayNotHasKey($forbidden, $schemas['Profile']['properties']);
+            $this->assertArrayNotHasKey($forbidden, $schemas['Space']['properties']);
             $this->assertArrayNotHasKey($forbidden, $schemas['Media']['properties']);
             $this->assertArrayNotHasKey($forbidden, $schemas['Notification']['properties']);
         }


### PR DESCRIPTION
## Summary

Adds the next read-only API slice for Spaces.

- exposes cursor-paginated `GET /api/v1/spaces` behind `spaces:read`
- exposes policy-safe `GET /api/v1/spaces/{slug}` behind `spaces:read`
- adds a strict Space API resource with viewer membership, role, and moderation state
- lets members grant `spaces:read` from the API token UI
- marks only the implemented Space operations as available in the public API docs/OpenAPI contract

## Validation

- `php artisan test tests/Feature/Api/VisibleSpaceTest.php tests/Feature/Settings/ApiTokenManagementTest.php tests/Unit/ApiContractDocumentationTest.php`
- `composer run ci:check`
- `npm run build`
- `composer validate --strict`
- `composer audit --no-interaction`
- `npm audit --omit=dev --audit-level=high`
- `npx @redocly/cli@2.13.0 lint docs/openapi.json`
