### PR TITLE
Add policy-filtered feed API and secure post media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable project changes will be documented here.
 - Policy-safe `GET /api/v1/profiles/{handle}` access under the separate
   `profiles:read` ability, preserving direct-link visibility, shared-Space
   privacy, mute state, and mutual block boundaries.
+- A `feed:read` API ability with `GET /api/v1/feed`, deterministic encrypted
+  cursor pagination, optional visible-Space filtering, policy-safe post
+  resources, and bearer-authorized normalized media delivery.
 - Optional single-image post attachments with required alternative text,
   private policy-protected delivery, bounded processing, and static WebP
   normalization that discards original metadata and filenames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,14 @@ All notable project changes will be documented here.
   20-comment pages, and policy-filtered access to older replies.
 - Database-backed in-app notifications for replies and new Space moderation
   reports, with unread state, secure destinations, and paginated history.
+- Notification mutation support for native clients: `PATCH
+  /api/v1/notifications/{notification}/read` and `PATCH
+  /api/v1/notifications/read-all`, preserving owner scope and policy-safe
+  mark-read behavior.
 - Per-member preferences for reply and moderation notification categories.
+- Cursor-paginated post detail and comments APIs for native clients with
+  policy-enforced access: `GET /api/v1/posts/{post}` and
+  `GET /api/v1/posts/{post}/comments`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -132,11 +132,12 @@ on a private disk, and authorized through their parent post. See
 [`docs/media.md`](docs/media.md) for the limits, lifecycle, and storage contract.
 
 The authenticated native/decoupled API is being developed contract-first. Its
-first available operations return the current safe profile and profiles already
-visible to that member. They use expiring, explicitly scoped bearer tokens
-created from recently confirmed Security settings. The remaining read-only
-draft fixes cursor pagination, throttling, CORS, stable errors, and policy-safe
-resources before more endpoints are exposed. See
+available operations expose the member's safe profile, visible profiles and
+Spaces, and a policy-filtered chronological feed with bearer-protected private
+images. Expiring, explicitly scoped tokens are created from recently confirmed
+Security settings. Cursor pagination, throttling, CORS, stable errors, and
+allowlisted resources are enforced before each planned endpoint becomes
+available. See
 [`docs/api-v1.md`](docs/api-v1.md) and the machine-readable
 [`docs/openapi.json`](docs/openapi.json).
 

--- a/app/Api/V1/FeedCursor.php
+++ b/app/Api/V1/FeedCursor.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Api\V1;
+
+use App\Exceptions\InvalidApiCursorException;
+use App\Models\Post;
+use App\Models\Space;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\Crypt;
+use JsonException;
+
+final class FeedCursor
+{
+    /**
+     * @return array{published_at: CarbonImmutable, post_id: int}
+     */
+    public function decode(string $cursor, User $viewer, ?Space $space): array
+    {
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode(
+                Crypt::decryptString($cursor),
+                true,
+                8,
+                JSON_THROW_ON_ERROR,
+            );
+        } catch (DecryptException|JsonException) {
+            throw new InvalidApiCursorException;
+        }
+
+        if (! is_array($decoded)
+            || array_keys($decoded) !== ['version', 'viewer_id', 'space_slug', 'published_at', 'post_id']
+            || $decoded['version'] !== 1
+            || $decoded['viewer_id'] !== $viewer->getKey()
+            || $decoded['space_slug'] !== $space?->slug
+            || ! is_int($decoded['published_at'])
+            || $decoded['published_at'] < 1
+            || ! is_int($decoded['post_id'])
+            || $decoded['post_id'] < 1) {
+            throw new InvalidApiCursorException;
+        }
+
+        return [
+            'published_at' => CarbonImmutable::createFromTimestampUTC($decoded['published_at']),
+            'post_id' => $decoded['post_id'],
+        ];
+    }
+
+    public function encode(User $viewer, ?Space $space, Post $post): string
+    {
+        $publishedAt = $post->published_at;
+
+        if ($publishedAt === null) {
+            throw new InvalidApiCursorException;
+        }
+
+        try {
+            $payload = json_encode([
+                'version' => 1,
+                'viewer_id' => $viewer->getKey(),
+                'space_slug' => $space?->slug,
+                'published_at' => $publishedAt->getTimestamp(),
+                'post_id' => $post->getKey(),
+            ], JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new InvalidApiCursorException;
+        }
+
+        return Crypt::encryptString($payload);
+    }
+}

--- a/app/Api/V1/NotificationCursor.php
+++ b/app/Api/V1/NotificationCursor.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Api\V1;
+
+use App\Exceptions\InvalidApiCursorException;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Crypt;
+use JsonException;
+
+final class NotificationCursor
+{
+    /**
+     * @return array{created_at: CarbonImmutable, notification_id: string}
+     */
+    public function decode(string $cursor, User $viewer, string $filter): array
+    {
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode(
+                Crypt::decryptString($cursor),
+                true,
+                8,
+                JSON_THROW_ON_ERROR,
+            );
+        } catch (DecryptException|JsonException) {
+            throw new InvalidApiCursorException;
+        }
+
+        if (! is_array($decoded)
+            || array_keys($decoded) !== ['version', 'viewer_id', 'filter', 'created_at', 'notification_id']
+            || $decoded['version'] !== 1
+            || $decoded['viewer_id'] !== $viewer->getKey()
+            || ! is_string($decoded['filter'])
+            || $decoded['filter'] !== $filter
+            || ! is_int($decoded['created_at'])
+            || $decoded['created_at'] < 1
+            || ! is_string($decoded['notification_id'])
+            || $decoded['notification_id'] === '') {
+            throw new InvalidApiCursorException;
+        }
+
+        return [
+            'created_at' => CarbonImmutable::createFromTimestampUTC($decoded['created_at']),
+            'notification_id' => $decoded['notification_id'],
+        ];
+    }
+
+    public function encode(User $viewer, string $filter, DatabaseNotification $notification): string
+    {
+        if ($notification->created_at === null || $notification->getKey() === null) {
+            throw new InvalidApiCursorException;
+        }
+
+        try {
+            $payload = json_encode([
+                'version' => 1,
+                'viewer_id' => $viewer->getKey(),
+                'filter' => $filter,
+                'created_at' => $notification->created_at->getTimestamp(),
+                'notification_id' => $notification->getKey(),
+            ], JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new InvalidApiCursorException;
+        }
+
+        return Crypt::encryptString($payload);
+    }
+}

--- a/app/Api/V1/PostCommentCursor.php
+++ b/app/Api/V1/PostCommentCursor.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Api\V1;
+
+use App\Exceptions\InvalidApiCursorException;
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\Crypt;
+use JsonException;
+
+final class PostCommentCursor
+{
+    /**
+     * @return array{published_at: CarbonImmutable, comment_id: int}
+     */
+    public function decode(string $cursor, User $viewer, Post $post): array
+    {
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode(
+                Crypt::decryptString($cursor),
+                true,
+                8,
+                JSON_THROW_ON_ERROR,
+            );
+        } catch (DecryptException|JsonException) {
+            throw new InvalidApiCursorException;
+        }
+
+        if (! is_array($decoded)
+            || array_keys($decoded) !== ['version', 'viewer_id', 'post_id', 'published_at', 'comment_id']
+            || $decoded['version'] !== 1
+            || $decoded['viewer_id'] !== $viewer->getKey()
+            || $decoded['post_id'] !== $post->getKey()
+            || ! is_int($decoded['published_at'])
+            || $decoded['published_at'] < 1
+            || ! is_int($decoded['comment_id'])
+            || $decoded['comment_id'] < 1) {
+            throw new InvalidApiCursorException;
+        }
+
+        return [
+            'published_at' => CarbonImmutable::createFromTimestampUTC($decoded['published_at']),
+            'comment_id' => $decoded['comment_id'],
+        ];
+    }
+
+    public function encode(User $viewer, Post $post, Comment $comment): string
+    {
+        if ($comment->post_id !== $post->getKey()) {
+            throw new InvalidApiCursorException;
+        }
+
+        try {
+            $payload = json_encode([
+                'version' => 1,
+                'viewer_id' => $viewer->getKey(),
+                'post_id' => $post->getKey(),
+                'published_at' => $comment->published_at->getTimestamp(),
+                'comment_id' => $comment->getKey(),
+            ], JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new InvalidApiCursorException;
+        }
+
+        return Crypt::encryptString($payload);
+    }
+}

--- a/app/Community/NotificationCenter.php
+++ b/app/Community/NotificationCenter.php
@@ -19,6 +19,39 @@ final class NotificationCenter
 
     /**
      * @return array{
+     *     id: string,
+     *     kind: string,
+     *     title: string,
+     *     description: string,
+     *     created_at: string,
+     *     read_at: string|null,
+     *     available: bool,
+     *     target: array{
+     *         type: string,
+     *         post_id?: string,
+     *         comment_id?: string,
+     *         space_slug?: string,
+     *     }|null
+     * }
+     */
+    public function apiItem(User $viewer, DatabaseNotification $notification): array
+    {
+        $resolved = $this->resolve($viewer, $notification);
+
+        return [
+            'id' => (string) $notification->getKey(),
+            'kind' => $resolved['kind'],
+            'title' => $resolved['title'],
+            'description' => $resolved['description'],
+            'created_at' => $notification->created_at->toIso8601String(),
+            'read_at' => $notification->read_at?->toIso8601String(),
+            'available' => $resolved['destination'] !== null,
+            'target' => $this->notificationApiTarget($viewer, $notification, $resolved),
+        ];
+    }
+
+    /**
+     * @return array{
      *     items: list<array{id: string, kind: string, title: string, description: string, createdAt: string, readAt: string|null, available: bool}>,
      *     meta: array{currentPage: int, lastPage: int, perPage: int, total: int},
      *     links: array{previous: string|null, next: string|null}
@@ -156,6 +189,101 @@ final class NotificationCenter
             'title' => 'New '.$reportKind.' report',
             'description' => 'Review the moderation queue in '.$space->name.'.',
             'destination' => route('spaces.moderation.index', $space),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     post_id?: string,
+     *     comment_id?: string,
+     *     space_slug?: string,
+     * }|null
+     */
+    private function notificationApiTarget(
+        User $viewer,
+        DatabaseNotification $notification,
+        array $resolved,
+    ): ?array {
+        return match (NotificationType::tryFrom($notification->type)) {
+            NotificationType::CommentReply => $this->notificationApiTargetForCommentReply($notification, $resolved),
+            NotificationType::SpaceModeration => $this->notificationApiTargetForSpaceModeration(
+                $viewer,
+                $notification,
+                $resolved,
+            ),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array{type: string, post_id: string, comment_id: string}|null
+     */
+    private function notificationApiTargetForCommentReply(
+        DatabaseNotification $notification,
+        array $resolved,
+    ): ?array {
+        if ($resolved['destination'] === null) {
+            return null;
+        }
+
+        $commentId = $this->integer($notification, 'comment_id');
+
+        if ($commentId === null) {
+            return null;
+        }
+
+        $comment = Comment::query()
+            ->with(['post'])
+            ->find($commentId);
+
+        return $comment instanceof Comment
+            ? [
+                'type' => 'post',
+                'post_id' => (string) $comment->post_id,
+                'comment_id' => (string) $comment->getKey(),
+            ]
+            : null;
+    }
+
+    /**
+     * @return array{type: string, space_slug: string}|null
+     */
+    private function notificationApiTargetForSpaceModeration(
+        User $viewer,
+        DatabaseNotification $notification,
+        array $resolved,
+    ): ?array {
+        if ($resolved['destination'] === null) {
+            return null;
+        }
+
+        $spaceId = $this->integer($notification, 'space_id');
+        $reportId = $this->integer($notification, 'report_id');
+        $reportKind = $notification->data['report_kind'] ?? null;
+
+        if ($spaceId === null || $reportId === null || ! in_array($reportKind, ['post', 'comment'], true)) {
+            return null;
+        }
+
+        $space = Space::query()->find($spaceId);
+
+        if (! $space instanceof Space
+            || Gate::forUser($viewer)->denies('moderate', $space)) {
+            return null;
+        }
+
+        $reportExists = $reportKind === 'post'
+            ? PostReport::query()->whereKey($reportId)->whereBelongsTo($space)->exists()
+            : CommentReport::query()->whereKey($reportId)->whereBelongsTo($space)->exists();
+
+        if (! $reportExists) {
+            return null;
+        }
+
+        return [
+            'type' => 'space_moderation',
+            'space_slug' => $space->slug,
         ];
     }
 

--- a/app/Community/NotificationCenter.php
+++ b/app/Community/NotificationCenter.php
@@ -193,6 +193,12 @@ final class NotificationCenter
     }
 
     /**
+     * @param array{
+     *     kind: string,
+     *     title: string,
+     *     description: string,
+     *     destination: string|null,
+     * } $resolved
      * @return array{
      *     type: string,
      *     post_id?: string,
@@ -217,7 +223,17 @@ final class NotificationCenter
     }
 
     /**
-     * @return array{type: string, post_id: string, comment_id: string}|null
+     * @param array{
+     *     kind: string,
+     *     title: string,
+     *     description: string,
+     *     destination: string|null,
+     * } $resolved
+     * @return array{
+     *     type: string,
+     *     post_id: string,
+     *     comment_id: string,
+     * }|null
      */
     private function notificationApiTargetForCommentReply(
         DatabaseNotification $notification,
@@ -247,7 +263,16 @@ final class NotificationCenter
     }
 
     /**
-     * @return array{type: string, space_slug: string}|null
+     * @param array{
+     *     kind: string,
+     *     title: string,
+     *     description: string,
+     *     destination: string|null,
+     * } $resolved
+     * @return array{
+     *     type: string,
+     *     space_slug: string,
+     * }|null
      */
     private function notificationApiTargetForSpaceModeration(
         User $viewer,

--- a/app/Community/VisiblePostQuery.php
+++ b/app/Community/VisiblePostQuery.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Community;
+
+use App\Enums\UserRelationshipType;
+use App\Models\Post;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+final class VisiblePostQuery
+{
+    /** @return Builder<Post> */
+    public function forFeed(User $viewer, ?Space $space = null): Builder
+    {
+        $hiddenActorIds = $this->hiddenActorIds($viewer);
+        $blockingActorIds = $this->blockingActorIds($viewer);
+        $visibleComments = fn (Builder $comments): Builder => $comments
+            ->whereNotNull('published_at')
+            ->whereNull('hidden_at')
+            ->whereNotIn('user_id', clone $hiddenActorIds)
+            ->whereNotIn('user_id', clone $blockingActorIds);
+
+        return $this->base($viewer, $space)
+            ->with([
+                'author:id,name,handle,headline',
+                'media',
+                'space' => fn ($spaces) => $spaces
+                    ->addSelect([
+                        'current_role' => DB::table('space_members')
+                            ->select('role')
+                            ->whereColumn('space_members.space_id', 'spaces.id')
+                            ->where('space_members.user_id', $viewer->getKey())
+                            ->limit(1),
+                    ])
+                    ->withExists([
+                        'members as is_member' => fn ($members) => $members
+                            ->whereKey($viewer->getKey()),
+                    ])
+                    ->withCount('members'),
+            ])
+            ->withCount(['comments as comments_count' => $visibleComments]);
+    }
+
+    public function findVisible(User $viewer, int|string $postId): Post
+    {
+        return $this->base($viewer)
+            ->with('media')
+            ->whereKey($postId)
+            ->firstOrFail();
+    }
+
+    /** @return Builder<Post> */
+    private function base(User $viewer, ?Space $space = null): Builder
+    {
+        $query = Post::query()
+            ->whereNotNull('published_at')
+            ->whereNull('hidden_at')
+            ->whereNotIn('user_id', $this->hiddenActorIds($viewer))
+            ->whereNotIn('user_id', $this->blockingActorIds($viewer));
+
+        if ($space instanceof Space) {
+            return $query->whereBelongsTo($space);
+        }
+
+        return $query->whereIn(
+            'space_id',
+            Space::query()->discoverableBy($viewer)->select('id'),
+        );
+    }
+
+    private function hiddenActorIds(User $viewer): \Illuminate\Database\Query\Builder
+    {
+        return DB::table('user_relationships')
+            ->select('target_id')
+            ->where('actor_id', $viewer->getKey())
+            ->whereIn('type', [
+                UserRelationshipType::Mute->value,
+                UserRelationshipType::Block->value,
+            ]);
+    }
+
+    private function blockingActorIds(User $viewer): \Illuminate\Database\Query\Builder
+    {
+        return DB::table('user_relationships')
+            ->select('actor_id')
+            ->where('target_id', $viewer->getKey())
+            ->where('type', UserRelationshipType::Block->value);
+    }
+}

--- a/app/Exceptions/InvalidApiCursorException.php
+++ b/app/Exceptions/InvalidApiCursorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class InvalidApiCursorException extends RuntimeException {}

--- a/app/Http/Controllers/Api/V1/FeedController.php
+++ b/app/Http/Controllers/Api/V1/FeedController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Api\V1\FeedCursor;
+use App\Community\VisiblePostQuery;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\PostResource;
+use App\Models\Post;
+use App\Models\PostReport;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class FeedController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        VisiblePostQuery $visiblePosts,
+        FeedCursor $cursors,
+    ): JsonResponse {
+        /** @var User $viewer */
+        $viewer = $request->user();
+        /** @var array{cursor?: string, limit?: int, space?: string} $validated */
+        $validated = $request->validate([
+            'cursor' => ['sometimes', 'string', 'max:2048'],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:50'],
+            'space' => ['sometimes', 'string', 'max:120'],
+        ]);
+        $limit = (int) ($validated['limit'] ?? 20);
+        $space = isset($validated['space'])
+            ? Space::query()
+                ->discoverableBy($viewer)
+                ->where('slug', $validated['space'])
+                ->firstOrFail()
+            : null;
+        $query = $visiblePosts->forFeed($viewer, $space);
+
+        if (isset($validated['cursor'])) {
+            $cursor = $cursors->decode($validated['cursor'], $viewer, $space);
+
+            $query->where(function (Builder $posts) use ($cursor): void {
+                $posts
+                    ->where('published_at', '<', $cursor['published_at'])
+                    ->orWhere(function (Builder $posts) use ($cursor): void {
+                        $posts
+                            ->where('published_at', $cursor['published_at'])
+                            ->where('id', '<', $cursor['post_id']);
+                    });
+            });
+        }
+
+        /** @var Collection<int, Post> $posts */
+        $posts = $query
+            ->latest('published_at')
+            ->latest('id')
+            ->limit($limit + 1)
+            ->get();
+        $hasMore = $posts->count() > $limit;
+        $posts = $posts->take($limit)->values();
+
+        $this->addViewerState($posts, $viewer);
+
+        $lastPost = $posts->last();
+        $nextCursor = $hasMore && $lastPost instanceof Post
+            ? $cursors->encode($viewer, $space, $lastPost)
+            : null;
+        $next = $nextCursor !== null
+            ? route('api.v1.feed', array_filter([
+                'cursor' => $nextCursor,
+                'limit' => $limit,
+                'space' => $space?->slug,
+            ], fn (mixed $value): bool => $value !== null))
+            : null;
+
+        return response()->json([
+            'data' => $posts
+                ->map(fn (Post $post): array => (new PostResource($post))->toArray($request))
+                ->all(),
+            'links' => [
+                'next' => $next,
+            ],
+            'meta' => [
+                'next_cursor' => $nextCursor,
+                'has_more' => $hasMore,
+                'limit' => $limit,
+            ],
+        ]);
+    }
+
+    /** @param Collection<int, Post> $posts */
+    private function addViewerState(Collection $posts, User $viewer): void
+    {
+        $postIds = $posts->modelKeys();
+        $authorIds = $posts->pluck('user_id')->unique()->values();
+        $spaceIds = $posts->pluck('space_id')->unique()->values();
+        $visibleAuthorIds = User::query()
+            ->visibleTo($viewer)
+            ->whereKey($authorIds)
+            ->pluck('id')
+            ->all();
+        $reportedPostIds = PostReport::query()
+            ->where('reporter_id', $viewer->getKey())
+            ->whereIn('post_id', $postIds)
+            ->pluck('post_id')
+            ->all();
+        $memberSpaceIds = DB::table('space_members')
+            ->where('user_id', $viewer->getKey())
+            ->whereIn('space_id', $spaceIds)
+            ->pluck('space_id')
+            ->all();
+
+        $posts->each(function (Post $post) use (
+            $viewer,
+            $visibleAuthorIds,
+            $reportedPostIds,
+            $memberSpaceIds,
+        ): void {
+            $post->setAttribute(
+                'author_profile_visible',
+                in_array($post->user_id, $visibleAuthorIds, true),
+            );
+            $post->setAttribute(
+                'viewer_can_comment',
+                in_array($post->space_id, $memberSpaceIds, true),
+            );
+            $post->setAttribute('viewer_can_report', $post->user_id !== $viewer->getKey());
+            $post->setAttribute(
+                'viewer_has_reported',
+                in_array($post->getKey(), $reportedPostIds, true),
+            );
+        });
+    }
+}

--- a/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/app/Http/Controllers/Api/V1/NotificationController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Api\V1\NotificationCursor;
+use App\Community\NotificationCenter;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Notifications\DatabaseNotification;
+
+class NotificationController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        NotificationCenter $center,
+        NotificationCursor $cursorFactory,
+    ): JsonResponse {
+        /** @var User $viewer */
+        $viewer = $request->user();
+
+        /** @var array{cursor?: string, limit?: int, filter?: string} $validated */
+        $validated = $request->validate([
+            'cursor' => ['sometimes', 'string', 'max:2048'],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:50'],
+            'filter' => ['sometimes', 'string', 'in:all,unread'],
+        ]);
+
+        $filter = $validated['filter'] ?? 'all';
+        $limit = (int) ($validated['limit'] ?? 20);
+
+        $query = DatabaseNotification::query()
+            ->where('notifiable_type', $viewer->getMorphClass())
+            ->where('notifiable_id', $viewer->getKey())
+            ->when($filter === 'unread', fn ($notifications) => $notifications->whereNull('read_at'))
+            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->limit($limit + 1);
+
+        if (isset($validated['cursor'])) {
+            $cursor = $cursorFactory->decode($validated['cursor'], $viewer, $filter);
+
+            $query->where(function ($notifications) use ($cursor): void {
+                $notifications
+                    ->where('created_at', '<', $cursor['created_at'])
+                    ->orWhere(function ($notifications) use ($cursor): void {
+                        $notifications
+                            ->where('created_at', $cursor['created_at'])
+                            ->where('id', '<', $cursor['notification_id']);
+                    });
+            });
+        }
+
+        /** @var Collection<int, DatabaseNotification> $notifications */
+        $notifications = $query->get();
+        $hasMore = $notifications->count() > $limit;
+        $notifications = $notifications->take($limit)->values();
+
+        $lastNotification = $notifications->last();
+        $nextCursor = $hasMore && $lastNotification instanceof DatabaseNotification
+            ? $cursorFactory->encode($viewer, $filter, $lastNotification)
+            : null;
+
+        $next = $nextCursor !== null
+            ? route('api.v1.notifications', array_filter([
+                'cursor' => $nextCursor,
+                'limit' => $limit,
+                'filter' => $filter === 'unread' ? $filter : null,
+            ], static fn (mixed $value): bool => $value !== null))
+            : null;
+
+        return response()->json([
+            'data' => $notifications
+                ->map(fn (DatabaseNotification $notification): array => $center->apiItem($viewer, $notification))
+                ->all(),
+            'links' => [
+                'next' => $next,
+            ],
+            'meta' => [
+                'next_cursor' => $nextCursor,
+                'has_more' => $hasMore,
+                'limit' => $limit,
+            ],
+        ]);
+    }
+
+    public function readOne(
+        Request $request,
+        string $notification,
+        NotificationCenter $center,
+    ): JsonResponse {
+        /** @var User $viewer */
+        $viewer = $request->user();
+
+        $center->findFor($viewer, $notification)->markAsRead();
+
+        return response()->json(null, 204);
+    }
+
+    public function readAll(Request $request): JsonResponse
+    {
+        /** @var User $viewer */
+        $viewer = $request->user();
+
+        DatabaseNotification::query()
+            ->where('notifiable_type', $viewer->getMorphClass())
+            ->where('notifiable_id', $viewer->getKey())
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/Api/V1/PostCommentController.php
+++ b/app/Http/Controllers/Api/V1/PostCommentController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Api\V1\PostCommentCursor;
+use App\Community\VisiblePostQuery;
+use App\Enums\UserRelationshipType;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\CommentResource;
+use App\Models\Comment;
+use App\Models\CommentReport;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PostCommentController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        string $post,
+        VisiblePostQuery $visiblePosts,
+        PostCommentCursor $cursorFactory,
+    ): JsonResponse {
+        /** @var User $viewer */
+        $viewer = $request->user();
+        /** @var array{cursor?: string, limit?: int} $validated */
+        $validated = $request->validate([
+            'cursor' => ['sometimes', 'string', 'max:2048'],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:50'],
+        ]);
+
+        $postModel = $visiblePosts->forFeed($viewer)
+            ->whereKey($post)
+            ->firstOrFail();
+        $limit = (int) ($validated['limit'] ?? 20);
+
+        $query = $this->visibleComments($viewer, $postModel);
+
+        if (isset($validated['cursor'])) {
+            $cursor = $cursorFactory->decode($validated['cursor'], $viewer, $postModel);
+
+            $query->where(function (Builder $comments) use ($cursor): void {
+                $comments
+                    ->where('published_at', '>', $cursor['published_at'])
+                    ->orWhere(function (Builder $comments) use ($cursor): void {
+                        $comments
+                            ->where('published_at', $cursor['published_at'])
+                            ->where('id', '>', $cursor['comment_id']);
+                    });
+            });
+        }
+
+        /** @var Collection<int, Comment> $comments */
+        $comments = $query
+            ->with('author:id,name,handle,headline')
+            ->orderBy('published_at')
+            ->orderBy('id')
+            ->limit($limit + 1)
+            ->get();
+
+        $hasMore = $comments->count() > $limit;
+        $comments = $comments->take($limit)->values();
+
+        /** @var list<int> $reportedCommentIds */
+        $reportedCommentIds = CommentReport::query()
+            ->where('reporter_id', $viewer->getKey())
+            ->whereIn('comment_id', $comments->pluck('id')->all())
+            ->pluck('comment_id')
+            ->toArray();
+
+        /** @var list<int> $visibleAuthorIds */
+        $visibleAuthorIds = User::query()
+            ->visibleTo($viewer)
+            ->whereKey($comments->pluck('user_id')->unique()->values())
+            ->pluck('id')
+            ->toArray();
+
+        $this->addViewerState($comments, $viewer, $reportedCommentIds, $visibleAuthorIds);
+
+        $lastComment = $comments->last();
+        $nextCursor = $hasMore && $lastComment instanceof Comment
+            ? $cursorFactory->encode($viewer, $postModel, $lastComment)
+            : null;
+
+        $next = $nextCursor !== null
+            ? route('api.v1.posts.comments', [
+                'post' => $postModel,
+                'cursor' => $nextCursor,
+                'limit' => $limit,
+            ])
+            : null;
+
+        return response()->json([
+            'data' => $comments
+                ->map(fn (Comment $comment): array => (new CommentResource($comment))->toArray($request))
+                ->all(),
+            'links' => [
+                'next' => $next,
+            ],
+            'meta' => [
+                'next_cursor' => $nextCursor,
+                'has_more' => $hasMore,
+                'limit' => $limit,
+            ],
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, Comment>  $comments
+     * @param  list<int>  $reportedCommentIds
+     * @param  list<int>  $visibleAuthorIds
+     */
+    private function addViewerState(
+        Collection $comments,
+        User $viewer,
+        array $reportedCommentIds,
+        array $visibleAuthorIds,
+    ): void {
+        $comments->each(function (Comment $comment) use (
+            $viewer,
+            $reportedCommentIds,
+            $visibleAuthorIds,
+        ): void {
+            $comment->setAttribute('viewer_can_report', $viewer->can('report', $comment));
+            $comment->setAttribute(
+                'viewer_has_reported',
+                in_array($comment->getKey(), $reportedCommentIds, true),
+            );
+            $comment->setAttribute(
+                'author_profile_visible',
+                in_array($comment->user_id, $visibleAuthorIds, true),
+            );
+        });
+    }
+
+    /** @return Builder<Comment> */
+    private function visibleComments(User $viewer, Post $post): Builder
+    {
+        $hiddenActorIds = DB::table('user_relationships')
+            ->select('target_id')
+            ->where('actor_id', $viewer->getKey())
+            ->whereIn('type', [
+                UserRelationshipType::Mute->value,
+                UserRelationshipType::Block->value,
+            ]);
+        $blockingActorIds = DB::table('user_relationships')
+            ->select('actor_id')
+            ->where('target_id', $viewer->getKey())
+            ->where('type', UserRelationshipType::Block->value);
+
+        return Comment::query()
+            ->whereBelongsTo($post)
+            ->whereNotNull('published_at')
+            ->whereNull('hidden_at')
+            ->whereNotIn('user_id', $hiddenActorIds)
+            ->whereNotIn('user_id', $blockingActorIds);
+    }
+}

--- a/app/Http/Controllers/Api/V1/PostController.php
+++ b/app/Http/Controllers/Api/V1/PostController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Community\VisiblePostQuery;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\PostResource;
+use App\Models\Post;
+use App\Models\PostReport;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PostController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        string $post,
+        VisiblePostQuery $visiblePosts,
+    ): JsonResponse {
+        /** @var User $viewer */
+        $viewer = $request->user();
+
+        $postModel = $visiblePosts->forFeed($viewer)
+            ->whereKey($post)
+            ->firstOrFail();
+
+        $this->addViewerState(new Collection([$postModel]), $viewer);
+
+        return response()->json([
+            'data' => (new PostResource($postModel))->toArray($request),
+        ]);
+    }
+
+    /** @param Collection<int, Post> $posts */
+    private function addViewerState(Collection $posts, User $viewer): void
+    {
+        $postIds = $posts->modelKeys();
+        $authorIds = $posts->pluck('user_id')->unique()->values();
+        $spaceIds = $posts->pluck('space_id')->unique()->values();
+        $visibleAuthorIds = User::query()
+            ->visibleTo($viewer)
+            ->whereKey($authorIds)
+            ->pluck('id')
+            ->all();
+        $reportedPostIds = PostReport::query()
+            ->where('reporter_id', $viewer->getKey())
+            ->whereIn('post_id', $postIds)
+            ->pluck('post_id')
+            ->all();
+        $memberSpaceIds = DB::table('space_members')
+            ->where('user_id', $viewer->getKey())
+            ->whereIn('space_id', $spaceIds)
+            ->pluck('space_id')
+            ->all();
+
+        $posts->each(function (Post $post) use (
+            $viewer,
+            $visibleAuthorIds,
+            $reportedPostIds,
+            $memberSpaceIds,
+        ): void {
+            $post->setAttribute(
+                'author_profile_visible',
+                in_array($post->user_id, $visibleAuthorIds, true),
+            );
+            $post->setAttribute(
+                'viewer_can_comment',
+                in_array($post->space_id, $memberSpaceIds, true),
+            );
+            $post->setAttribute('viewer_can_report', $post->user_id !== $viewer->getKey());
+            $post->setAttribute(
+                'viewer_has_reported',
+                in_array($post->getKey(), $reportedPostIds, true),
+            );
+        });
+    }
+}

--- a/app/Http/Controllers/Api/V1/PostMediaController.php
+++ b/app/Http/Controllers/Api/V1/PostMediaController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Community\VisiblePostQuery;
+use App\Http\Controllers\Controller;
+use App\Models\PostMedia;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+
+class PostMediaController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        string $post,
+        VisiblePostQuery $visiblePosts,
+    ): Response {
+        /** @var User $viewer */
+        $viewer = $request->user();
+        $visiblePost = $visiblePosts->findVisible($viewer, $post);
+        $media = $visiblePost->media;
+
+        abort_unless($media instanceof PostMedia, 404);
+
+        $storage = Storage::disk($media->disk);
+
+        abort_unless($storage->exists($media->path), 404);
+
+        $contents = $storage->get($media->path);
+        $response = response($contents, 200, [
+            'Content-Type' => $media->mime_type,
+            'Content-Length' => (string) strlen($contents),
+            'Content-Disposition' => 'inline; filename="post-image.webp"',
+            'X-Content-Type-Options' => 'nosniff',
+            'Cross-Origin-Resource-Policy' => 'same-site',
+            'Vary' => 'Authorization, Origin',
+        ]);
+        $response->setPrivate();
+        $response->setMaxAge(3600);
+        $response->setEtag($media->checksum);
+        $response->isNotModified($request);
+
+        return $response;
+    }
+}

--- a/app/Http/Requests/Settings/StoreApiTokenRequest.php
+++ b/app/Http/Requests/Settings/StoreApiTokenRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Settings;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class StoreApiTokenRequest extends FormRequest
 {
@@ -19,13 +20,28 @@ class StoreApiTokenRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'min:2', 'max:80'],
-            'abilities' => ['required', 'array', 'min:1', 'max:3'],
+            'abilities' => ['required', 'array', 'min:1', 'max:4'],
             'abilities.*' => [
                 'required',
                 'string',
                 'distinct',
-                Rule::in(['profile:read', 'profiles:read', 'spaces:read']),
+                Rule::in(['profile:read', 'profiles:read', 'spaces:read', 'feed:read']),
             ],
         ];
+    }
+
+    /** @return array<int, callable(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            $abilities = $this->input('abilities');
+
+            if (is_array($abilities) && ! in_array('profile:read', $abilities, true)) {
+                $validator->errors()->add(
+                    'abilities',
+                    'Every API token must include own-profile access.',
+                );
+            }
+        }];
     }
 }

--- a/app/Http/Resources/Api/V1/CommentResource.php
+++ b/app/Http/Resources/Api/V1/CommentResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Comment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Comment */
+class CommentResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        /** @var Comment $comment */
+        $comment = $this->resource;
+
+        return [
+            'id' => (string) $comment->getKey(),
+            'body' => $comment->body,
+            'published_at' => $comment->published_at->toIso8601String(),
+            'author' => [
+                'handle' => $comment->author->handle,
+                'name' => $comment->author->name,
+                'headline' => $comment->author->headline,
+                'profile_visible' => (bool) $comment->getAttribute('author_profile_visible'),
+            ],
+            'viewer' => [
+                'can_report' => (bool) $comment->getAttribute('viewer_can_report'),
+                'has_reported' => (bool) $comment->getAttribute('viewer_has_reported'),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/PostResource.php
+++ b/app/Http/Resources/Api/V1/PostResource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Post;
+use App\Models\PostMedia;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Post */
+class PostResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        /** @var Post $post */
+        $post = $this->resource;
+        $media = $post->media;
+
+        return [
+            'id' => (string) $post->getKey(),
+            'body' => $post->body,
+            'published_at' => $post->published_at?->toIso8601String(),
+            'media' => $media instanceof PostMedia ? [
+                'url' => route('api.v1.posts.media', $post),
+                'alt' => $media->alt_text,
+                'width' => $media->width,
+                'height' => $media->height,
+                'mime_type' => $media->mime_type,
+            ] : null,
+            'comments_count' => (int) ($post->getAttribute('comments_count') ?? 0),
+            'author' => [
+                'handle' => $post->author->handle,
+                'name' => $post->author->name,
+                'headline' => $post->author->headline,
+                'profile_visible' => (bool) $post->getAttribute('author_profile_visible'),
+            ],
+            'space' => (new SpaceResource($post->space))->toArray($request),
+            'viewer' => [
+                'can_comment' => (bool) $post->getAttribute('viewer_can_comment'),
+                'can_report' => (bool) $post->getAttribute('viewer_can_report'),
+                'has_reported' => (bool) $post->getAttribute('viewer_has_reported'),
+            ],
+        ];
+    }
+}

--- a/app/Http/Responses/ApiErrorResponse.php
+++ b/app/Http/Responses/ApiErrorResponse.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Responses;
 
+use App\Exceptions\InvalidApiCursorException;
 use App\Http\Middleware\AssignApiRequestId;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
@@ -29,6 +30,15 @@ final class ApiErrorResponse
                 'validation_failed',
                 422,
                 $exception->errors(),
+            );
+        }
+
+        if ($exception instanceof InvalidApiCursorException) {
+            return self::make(
+                $request,
+                'The cursor is invalid for this request.',
+                'invalid_cursor',
+                400,
             );
         }
 

--- a/database/migrations/2026_07_21_000001_add_feed_cursor_index_to_posts_table.php
+++ b/database/migrations/2026_07_21_000001_add_feed_cursor_index_to_posts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->index(['published_at', 'id'], 'posts_feed_cursor_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->dropIndex('posts_feed_cursor_index');
+        });
+    }
+};

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -4,8 +4,9 @@
 
 This document defines the first public contract for authenticated native and
 decoupled clients. `GET /api/v1/me`, `GET /api/v1/profiles/{handle}`,
-`GET /api/v1/spaces`, and `GET /api/v1/spaces/{slug}` are available; the
-other endpoints in `openapi.json` remain **planned, not yet implemented**.
+`GET /api/v1/spaces`, `GET /api/v1/spaces/{slug}`, `GET /api/v1/feed`, and
+`GET /api/v1/posts/{post}/media` are available; the other endpoints in
+`openapi.json` remain **planned, not yet implemented**.
 Contract-first development keeps client expectations separate from the current
 Inertia view models and prevents accidental exposure of raw database records.
 
@@ -212,16 +213,16 @@ The read-only API roadmap contains:
 - `GET /api/v1/profiles/{handle}` — available
 - `GET /api/v1/spaces` — available
 - `GET /api/v1/spaces/{slug}` — available
-- `GET /api/v1/feed`
+- `GET /api/v1/feed` — available
 - `GET /api/v1/posts/{post}`
 - `GET /api/v1/posts/{post}/comments`
-- `GET /api/v1/posts/{post}/media`
+- `GET /api/v1/posts/{post}/media` — available
 - `GET /api/v1/notifications`
 
 OpenAPI operations carry `x-lineweb-status: planned` until their routes,
-resources, authorization, throttling, and feature tests exist. Only `/me` and
-`/profiles/{handle}`, `/spaces`, and `/spaces/{slug}` currently carry
-`x-lineweb-status: available`.
+resources, authorization, throttling, and feature tests exist. `/me`,
+`/profiles/{handle}`, `/spaces`, `/spaces/{slug}`, `/feed`, and
+`/posts/{post}/media` currently carry `x-lineweb-status: available`.
 Documentation must never make a planned endpoint look available.
 
 ## Implementation acceptance gates

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -4,15 +4,15 @@
 
 This document defines the first public contract for authenticated native and
 decoupled clients. `GET /api/v1/me`, `GET /api/v1/profiles/{handle}`,
-`GET /api/v1/spaces`, `GET /api/v1/spaces/{slug}`, `GET /api/v1/feed`, and
-`GET /api/v1/posts/{post}/media` are available; the other endpoints in
-`openapi.json` remain **planned, not yet implemented**.
+`GET /api/v1/spaces`, `GET /api/v1/spaces/{slug}`, `GET /api/v1/feed`,
+`GET /api/v1/posts/{post}`, `GET /api/v1/posts/{post}/comments`, 
+`GET /api/v1/posts/{post}/media`, `GET /api/v1/notifications`,
+`PATCH /api/v1/notifications/{notification}/read`, and
+`PATCH /api/v1/notifications/read-all` are available;
+the remaining endpoints in
+`openapi.json` are planned.
 Contract-first development keeps client expectations separate from the current
 Inertia view models and prevents accidental exposure of raw database records.
-
-The first implementation slice is deliberately read-only. Write operations,
-interactive native login, third-party OAuth, webhooks, and realtime delivery
-need separate reviews before they enter the contract.
 
 ## Compatibility boundary
 
@@ -61,7 +61,7 @@ member's password inside another application.
 
 ## Token abilities
 
-The read-only slice recognizes these abilities:
+The current slice recognizes these abilities:
 
 | Ability | Access |
 | --- | --- |
@@ -69,15 +69,16 @@ The read-only slice recognizes these abilities:
 | `profiles:read` | Profiles already visible to the member. |
 | `spaces:read` | Discoverable Spaces and viewer membership state. |
 | `feed:read` | Policy-filtered feed, posts, comments, and private post media. |
-| `notifications:read` | The member's policy-resolved notification history. |
+| `notifications:read` | Read the member's policy-resolved notification history. |
+| `notifications:write` | Mark one or all notifications as read. |
 
 Abilities are an additional boundary, not authorization by themselves. Every
 request must still pass the same policies, visibility scopes, membership rules,
 mute/block boundaries, and moderation state as the web application.
 
 Future write abilities are reserved but are not granted or accepted by the
-first slice: `posts:write`, `comments:write`, `memberships:write`,
-`relationships:write`, and `notifications:write`.
+current slice: `posts:write`, `comments:write`, `memberships:write`,
+and `relationships:write`.
 
 ## Response shape
 
@@ -130,7 +131,8 @@ contain exception messages, stack traces, SQL, filesystem paths, internal model
 names, or policy details. Responses include the same opaque `X-Request-ID` in
 the header for support correlation.
 
-Standard status codes are `200`, `400`, `401`, `403`, `404`, `422`, and `429`.
+Standard status codes are `200`, `204`, `400`, `401`, `403`, `404`, `422`, and
+`429`.
 The API uses `404` instead of confirming that inaccessible private content
 exists when that distinction would leak information.
 
@@ -205,24 +207,28 @@ must fetch the image with its API client and render a local object URL; placing
 the API URL directly in an `<img>` element will not attach the bearer token.
 Public or long-lived signed media URLs are intentionally outside this draft.
 
-## Read-only endpoint slice
+## Endpoint implementation status
 
-The read-only API roadmap contains:
+The implemented API roadmap contains:
 
 - `GET /api/v1/me` — available
 - `GET /api/v1/profiles/{handle}` — available
 - `GET /api/v1/spaces` — available
 - `GET /api/v1/spaces/{slug}` — available
 - `GET /api/v1/feed` — available
-- `GET /api/v1/posts/{post}`
-- `GET /api/v1/posts/{post}/comments`
+- `GET /api/v1/posts/{post}` — available
+- `GET /api/v1/posts/{post}/comments` — available
 - `GET /api/v1/posts/{post}/media` — available
-- `GET /api/v1/notifications`
+- `GET /api/v1/notifications` — available
+- `PATCH /api/v1/notifications/{notification}/read` — available
+- `PATCH /api/v1/notifications/read-all` — available
 
 OpenAPI operations carry `x-lineweb-status: planned` until their routes,
 resources, authorization, throttling, and feature tests exist. `/me`,
-`/profiles/{handle}`, `/spaces`, `/spaces/{slug}`, `/feed`, and
-`/posts/{post}/media` currently carry `x-lineweb-status: available`.
+`/profiles/{handle}`, `/spaces`, `/spaces/{slug}`, `/feed`,
+`/posts/{post}`, `/posts/{post}/comments`, `/posts/{post}/media`, and
+`/notifications`, `/notifications/{notification}/read`, and `/notifications/read-all`
+currently carry `x-lineweb-status: available`.
 Documentation must never make a planned endpoint look available.
 
 ## Implementation acceptance gates

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -21,131 +21,31 @@
     }
   ],
   "paths": {
-    "/me": {
-      "get": {
-        "operationId": "getCurrentProfile",
-        "summary": "Return the authenticated member's safe profile",
-        "tags": ["Profiles"],
-        "x-lineweb-status": "available",
-        "x-required-ability": "profile:read",
-        "responses": {
-          "200": {
-            "description": "Current profile",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileResponse"
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
-        }
-      }
-    },
-    "/profiles/{handle}": {
-      "get": {
-        "operationId": "getProfile",
-        "summary": "Return a profile already visible to the member",
-        "tags": ["Profiles"],
-        "x-lineweb-status": "available",
-        "x-required-ability": "profiles:read",
-        "parameters": [
-          { "$ref": "#/components/parameters/ProfileHandle" }
-        ],
-        "responses": {
-          "200": {
-            "description": "Visible profile",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileResponse"
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
-        }
-      }
-    },
-    "/spaces": {
-      "get": {
-        "operationId": "listSpaces",
-        "summary": "List Spaces discoverable by the member",
-        "tags": ["Spaces"],
-        "x-lineweb-status": "available",
-        "x-required-ability": "spaces:read",
-        "parameters": [
-          { "$ref": "#/components/parameters/Cursor" },
-          { "$ref": "#/components/parameters/Limit" }
-        ],
-        "responses": {
-          "200": {
-            "description": "Discoverable Spaces",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SpaceCollection"
-                }
-              }
-            }
-          },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
-        }
-      }
-    },
-    "/spaces/{slug}": {
-      "get": {
-        "operationId": "getSpace",
-        "summary": "Return one Space visible to the member",
-        "tags": ["Spaces"],
-        "x-lineweb-status": "available",
-        "x-required-ability": "spaces:read",
-        "parameters": [
-          { "$ref": "#/components/parameters/SpaceSlug" }
-        ],
-        "responses": {
-          "200": {
-            "description": "Visible Space",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SpaceResponse"
-                }
-              }
-            }
-          },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
-        }
-      }
-    },
     "/feed": {
       "get": {
         "operationId": "getFeed",
         "summary": "Return the member's policy-filtered chronological feed",
-        "tags": ["Feed"],
+        "tags": [
+          "Feed"
+        ],
         "x-lineweb-status": "available",
         "x-required-ability": "feed:read",
         "parameters": [
-          { "$ref": "#/components/parameters/Cursor" },
-          { "$ref": "#/components/parameters/Limit" },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
           {
             "name": "space",
             "in": "query",
             "required": false,
             "description": "Optional visible Space slug.",
-            "schema": { "type": "string", "maxLength": 120 }
+            "schema": {
+              "type": "string",
+              "maxLength": 120
+            }
           }
         ],
         "responses": {
@@ -159,105 +59,56 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/ValidationFailed" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
-        }
-      }
-    },
-    "/posts/{post}": {
-      "get": {
-        "operationId": "getPost",
-        "summary": "Return one visible post",
-        "tags": ["Posts"],
-        "x-lineweb-status": "planned",
-        "x-required-ability": "feed:read",
-        "parameters": [
-          { "$ref": "#/components/parameters/PostId" }
-        ],
-        "responses": {
-          "200": {
-            "description": "Visible post",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PostResponse"
-                }
-              }
-            }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
-        }
-      }
-    },
-    "/posts/{post}/comments": {
-      "get": {
-        "operationId": "listPostComments",
-        "summary": "Return visible comments in chronological order",
-        "tags": ["Posts"],
-        "x-lineweb-status": "planned",
-        "x-required-ability": "feed:read",
-        "parameters": [
-          { "$ref": "#/components/parameters/PostId" },
-          { "$ref": "#/components/parameters/Cursor" },
-          { "$ref": "#/components/parameters/Limit" }
-        ],
-        "responses": {
-          "200": {
-            "description": "Chronological visible comments",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CommentCollection"
-                }
-              }
-            }
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationFailed"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
         }
       }
     },
-    "/posts/{post}/media": {
+    "/me": {
       "get": {
-        "operationId": "getPostMedia",
-        "summary": "Return the authorized normalized post image",
-        "tags": ["Posts"],
+        "operationId": "getCurrentProfile",
+        "summary": "Return the authenticated member's safe profile",
+        "tags": [
+          "Profiles"
+        ],
         "x-lineweb-status": "available",
-        "x-required-ability": "feed:read",
-        "parameters": [
-          { "$ref": "#/components/parameters/PostId" }
-        ],
+        "x-required-ability": "profile:read",
         "responses": {
           "200": {
-            "description": "Static normalized WebP image",
-            "headers": {
-              "Content-Type": {
-                "schema": { "type": "string", "const": "image/webp" }
-              },
-              "Cross-Origin-Resource-Policy": {
-                "schema": { "type": "string", "enum": ["same-site"] }
-              }
-            },
+            "description": "Current profile",
             "content": {
-              "image/webp": {
-                "schema": { "type": "string", "contentEncoding": "binary" }
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
         }
       }
     },
@@ -265,19 +116,28 @@
       "get": {
         "operationId": "listNotifications",
         "summary": "Return the member's policy-resolved notifications",
-        "tags": ["Notifications"],
-        "x-lineweb-status": "planned",
+        "tags": [
+          "Notifications"
+        ],
+        "x-lineweb-status": "available",
         "x-required-ability": "notifications:read",
         "parameters": [
-          { "$ref": "#/components/parameters/Cursor" },
-          { "$ref": "#/components/parameters/Limit" },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
           {
             "name": "filter",
             "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["all", "unread"],
+              "enum": [
+                "all",
+                "unread"
+              ],
               "default": "all"
             }
           }
@@ -293,10 +153,455 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthenticated" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "429": { "$ref": "#/components/responses/TooManyRequests" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationFailed"
+          }
+        }
+      }
+    },
+    "/notifications/read-all": {
+      "patch": {
+        "operationId": "markAllNotificationsRead",
+        "summary": "Mark all notifications as read",
+        "tags": [
+          "Notifications"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "notifications:write",
+        "responses": {
+          "204": {
+            "description": "All unread notifications marked as read"
+          },
+          "401": {
+            "description": "Missing, expired, or revoked token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The verified member or token ability cannot perform this request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The current rate limit was exceeded.",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "X-RateLimit-Limit": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "X-RateLimit-Reset": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/{notification}/read": {
+      "patch": {
+        "operationId": "markNotificationRead",
+        "summary": "Mark one notification as read",
+        "tags": [
+          "Notifications"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "notifications:write",
+        "parameters": [
+          {
+            "name": "notification",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Database notification id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Notification marked as read"
+          },
+          "401": {
+            "description": "Missing, expired, or revoked token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The verified member or token ability cannot perform this request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested notification does not exist or is not accessible",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "The current rate limit was exceeded.",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "X-RateLimit-Limit": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "X-RateLimit-Reset": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/posts/{post}": {
+      "get": {
+        "operationId": "getPost",
+        "summary": "Return one visible post",
+        "tags": [
+          "Posts"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "feed:read",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PostId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Visible post",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/posts/{post}/comments": {
+      "get": {
+        "operationId": "listPostComments",
+        "summary": "Return visible comments in chronological order",
+        "tags": [
+          "Posts"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "feed:read",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PostId"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chronological visible comments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/posts/{post}/media": {
+      "get": {
+        "operationId": "getPostMedia",
+        "summary": "Return the authorized normalized post image",
+        "tags": [
+          "Posts"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "feed:read",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PostId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Static normalized WebP image",
+            "headers": {
+              "Content-Type": {
+                "schema": {
+                  "type": "string",
+                  "const": "image/webp"
+                }
+              },
+              "Cross-Origin-Resource-Policy": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "same-site"
+                  ]
+                }
+              }
+            },
+            "content": {
+              "image/webp": {
+                "schema": {
+                  "type": "string",
+                  "contentEncoding": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/profiles/{handle}": {
+      "get": {
+        "operationId": "getProfile",
+        "summary": "Return a profile already visible to the member",
+        "tags": [
+          "Profiles"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "profiles:read",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ProfileHandle"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Visible profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/spaces": {
+      "get": {
+        "operationId": "listSpaces",
+        "summary": "List Spaces discoverable by the member",
+        "tags": [
+          "Spaces"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "spaces:read",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Discoverable Spaces",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpaceCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    },
+    "/spaces/{slug}": {
+      "get": {
+        "operationId": "getSpace",
+        "summary": "Return one Space visible to the member",
+        "tags": [
+          "Spaces"
+        ],
+        "x-lineweb-status": "available",
+        "x-required-ability": "spaces:read",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/SpaceSlug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Visible Space",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpaceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
         }
       }
     }
@@ -316,7 +621,10 @@
         "in": "query",
         "required": false,
         "description": "Opaque cursor returned by the previous response.",
-        "schema": { "type": "string", "maxLength": 2048 }
+        "schema": {
+          "type": "string",
+          "maxLength": 2048
+        }
       },
       "Limit": {
         "name": "limit",
@@ -333,20 +641,31 @@
         "name": "handle",
         "in": "path",
         "required": true,
-        "schema": { "type": "string", "minLength": 1, "maxLength": 50 }
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        }
       },
       "SpaceSlug": {
         "name": "slug",
         "in": "path",
         "required": true,
-        "schema": { "type": "string", "minLength": 1, "maxLength": 120 }
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 120
+        }
       },
       "PostId": {
         "name": "post",
         "in": "path",
         "required": true,
         "description": "Opaque post identifier.",
-        "schema": { "type": "string", "minLength": 1 }
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "responses": {
@@ -354,7 +673,9 @@
         "description": "Malformed input or a cursor used outside its original query.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -362,7 +683,9 @@
         "description": "Missing, expired, or revoked token.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -370,7 +693,9 @@
         "description": "The verified member or token ability cannot perform this request.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -378,7 +703,9 @@
         "description": "The resource does not exist or is not visible to the member.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -386,7 +713,9 @@
         "description": "One or more query parameters failed validation.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -394,21 +723,35 @@
         "description": "The current rate limit was exceeded.",
         "headers": {
           "Retry-After": {
-            "schema": { "type": "integer", "minimum": 1 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           },
           "X-RateLimit-Limit": {
-            "schema": { "type": "integer", "minimum": 1 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           },
           "X-RateLimit-Remaining": {
-            "schema": { "type": "integer", "minimum": 0 }
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
           },
           "X-RateLimit-Reset": {
-            "schema": { "type": "integer", "minimum": 0 }
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         },
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       }
@@ -417,16 +760,30 @@
       "Error": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["message", "code", "request_id"],
+        "required": [
+          "message",
+          "code",
+          "request_id"
+        ],
         "properties": {
-          "message": { "type": "string" },
-          "code": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
-          "request_id": { "type": "string", "format": "uuid" },
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "request_id": {
+            "type": "string",
+            "format": "uuid"
+          },
           "errors": {
             "type": "object",
             "additionalProperties": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -434,51 +791,134 @@
       "PaginationLinks": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["next"],
+        "required": [
+          "next"
+        ],
         "properties": {
-          "next": { "type": ["string", "null"], "format": "uri-reference" }
+          "next": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri-reference"
+          }
         }
       },
       "PaginationMeta": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["next_cursor", "has_more", "limit"],
+        "required": [
+          "next_cursor",
+          "has_more",
+          "limit"
+        ],
         "properties": {
-          "next_cursor": { "type": ["string", "null"] },
-          "has_more": { "type": "boolean" },
-          "limit": { "type": "integer", "minimum": 1, "maximum": 50 }
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50
+          }
         }
       },
       "ProfileSummary": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["handle", "name", "headline", "profile_visible"],
+        "required": [
+          "handle",
+          "name",
+          "headline",
+          "profile_visible"
+        ],
         "properties": {
-          "handle": { "type": "string" },
-          "name": { "type": "string" },
-          "headline": { "type": ["string", "null"] },
-          "profile_visible": { "type": "boolean" }
+          "handle": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "headline": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "profile_visible": {
+            "type": "boolean"
+          }
         }
       },
       "Profile": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["handle", "name", "headline", "bio", "location", "website_url", "member_since", "viewer"],
+        "required": [
+          "handle",
+          "name",
+          "headline",
+          "bio",
+          "location",
+          "website_url",
+          "member_since",
+          "viewer"
+        ],
         "properties": {
-          "handle": { "type": "string" },
-          "name": { "type": "string" },
-          "headline": { "type": ["string", "null"] },
-          "bio": { "type": ["string", "null"] },
-          "location": { "type": ["string", "null"] },
-          "website_url": { "type": ["string", "null"], "format": "uri" },
-          "member_since": { "type": "string", "format": "date" },
+          "handle": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "headline": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bio": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "location": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "website_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "member_since": {
+            "type": "string",
+            "format": "date"
+          },
           "viewer": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["is_self", "is_muted"],
+            "required": [
+              "is_self",
+              "is_muted"
+            ],
             "properties": {
-              "is_self": { "type": "boolean" },
-              "is_muted": { "type": "boolean" }
+              "is_self": {
+                "type": "boolean"
+              },
+              "is_muted": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -486,29 +926,78 @@
       "ProfileResponse": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
-          "data": { "$ref": "#/components/schemas/Profile" }
+          "data": {
+            "$ref": "#/components/schemas/Profile"
+          }
         }
       },
       "Space": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["slug", "name", "description", "visibility", "member_count", "viewer"],
+        "required": [
+          "slug",
+          "name",
+          "description",
+          "visibility",
+          "member_count",
+          "viewer"
+        ],
         "properties": {
-          "slug": { "type": "string" },
-          "name": { "type": "string" },
-          "description": { "type": ["string", "null"] },
-          "visibility": { "type": "string", "enum": ["public", "private", "hidden"] },
-          "member_count": { "type": "integer", "minimum": 0 },
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private",
+              "hidden"
+            ]
+          },
+          "member_count": {
+            "type": "integer",
+            "minimum": 0
+          },
           "viewer": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["is_member", "role", "can_manage"],
+            "required": [
+              "is_member",
+              "role",
+              "can_manage"
+            ],
             "properties": {
-              "is_member": { "type": "boolean" },
-              "role": { "type": ["string", "null"], "enum": ["owner", "moderator", "member", null] },
-              "can_manage": { "type": "boolean" }
+              "is_member": {
+                "type": "boolean"
+              },
+              "role": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "owner",
+                  "moderator",
+                  "member",
+                  null
+                ]
+              },
+              "can_manage": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -516,49 +1005,111 @@
       "SpaceResponse": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
-          "data": { "$ref": "#/components/schemas/Space" }
+          "data": {
+            "$ref": "#/components/schemas/Space"
+          }
         }
       },
       "SpaceCollection": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data", "links", "meta"],
+        "required": [
+          "data",
+          "links",
+          "meta"
+        ],
         "properties": {
-          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Space" } },
-          "links": { "$ref": "#/components/schemas/PaginationLinks" },
-          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Space"
+            }
+          },
+          "links": {
+            "$ref": "#/components/schemas/PaginationLinks"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
         }
       },
       "Media": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["url", "alt", "width", "height", "mime_type"],
+        "required": [
+          "url",
+          "alt",
+          "width",
+          "height",
+          "mime_type"
+        ],
         "properties": {
-          "url": { "type": "string", "format": "uri-reference" },
-          "alt": { "type": "string" },
-          "width": { "type": "integer", "minimum": 1, "maximum": 2048 },
-          "height": { "type": "integer", "minimum": 1, "maximum": 2048 },
-          "mime_type": { "type": "string", "const": "image/webp" }
+          "url": {
+            "type": "string",
+            "format": "uri-reference"
+          },
+          "alt": {
+            "type": "string"
+          },
+          "width": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2048
+          },
+          "height": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2048
+          },
+          "mime_type": {
+            "type": "string",
+            "const": "image/webp"
+          }
         }
       },
       "Comment": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "body", "published_at", "author", "viewer"],
+        "required": [
+          "id",
+          "body",
+          "published_at",
+          "author",
+          "viewer"
+        ],
         "properties": {
-          "id": { "type": "string" },
-          "body": { "type": "string", "maxLength": 1000 },
-          "published_at": { "type": "string", "format": "date-time" },
-          "author": { "$ref": "#/components/schemas/ProfileSummary" },
+          "id": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "author": {
+            "$ref": "#/components/schemas/ProfileSummary"
+          },
           "viewer": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["can_report", "has_reported"],
+            "required": [
+              "can_report",
+              "has_reported"
+            ],
             "properties": {
-              "can_report": { "type": "boolean" },
-              "has_reported": { "type": "boolean" }
+              "can_report": {
+                "type": "boolean"
+              },
+              "has_reported": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -566,28 +1117,66 @@
       "Post": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "body", "published_at", "media", "comments_count", "author", "space", "viewer"],
+        "required": [
+          "id",
+          "body",
+          "published_at",
+          "media",
+          "comments_count",
+          "author",
+          "space",
+          "viewer"
+        ],
         "properties": {
-          "id": { "type": "string" },
-          "body": { "type": "string", "maxLength": 2000 },
-          "published_at": { "type": "string", "format": "date-time" },
+          "id": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "published_at": {
+            "type": "string",
+            "format": "date-time"
+          },
           "media": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Media" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Media"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
-          "comments_count": { "type": "integer", "minimum": 0 },
-          "author": { "$ref": "#/components/schemas/ProfileSummary" },
-          "space": { "$ref": "#/components/schemas/Space" },
+          "comments_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "author": {
+            "$ref": "#/components/schemas/ProfileSummary"
+          },
+          "space": {
+            "$ref": "#/components/schemas/Space"
+          },
           "viewer": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["can_comment", "can_report", "has_reported"],
+            "required": [
+              "can_comment",
+              "can_report",
+              "has_reported"
+            ],
             "properties": {
-              "can_comment": { "type": "boolean" },
-              "can_report": { "type": "boolean" },
-              "has_reported": { "type": "boolean" }
+              "can_comment": {
+                "type": "boolean"
+              },
+              "can_report": {
+                "type": "boolean"
+              },
+              "has_reported": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -595,58 +1184,139 @@
       "PostResponse": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
-          "data": { "$ref": "#/components/schemas/Post" }
+          "data": {
+            "$ref": "#/components/schemas/Post"
+          }
         }
       },
       "PostCollection": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data", "links", "meta"],
+        "required": [
+          "data",
+          "links",
+          "meta"
+        ],
         "properties": {
-          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Post" } },
-          "links": { "$ref": "#/components/schemas/PaginationLinks" },
-          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Post"
+            }
+          },
+          "links": {
+            "$ref": "#/components/schemas/PaginationLinks"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
         }
       },
       "CommentCollection": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data", "links", "meta"],
+        "required": [
+          "data",
+          "links",
+          "meta"
+        ],
         "properties": {
-          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Comment" } },
-          "links": { "$ref": "#/components/schemas/PaginationLinks" },
-          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Comment"
+            }
+          },
+          "links": {
+            "$ref": "#/components/schemas/PaginationLinks"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
         }
       },
       "NotificationTarget": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "properties": {
-          "type": { "type": "string", "enum": ["post", "space_moderation"] },
-          "post_id": { "type": "string" },
-          "comment_id": { "type": "string" },
-          "space_slug": { "type": "string" }
+          "type": {
+            "type": "string",
+            "enum": [
+              "post",
+              "space_moderation"
+            ]
+          },
+          "post_id": {
+            "type": "string"
+          },
+          "comment_id": {
+            "type": "string"
+          },
+          "space_slug": {
+            "type": "string"
+          }
         }
       },
       "Notification": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "kind", "title", "description", "created_at", "read_at", "available", "target"],
+        "required": [
+          "id",
+          "kind",
+          "title",
+          "description",
+          "created_at",
+          "read_at",
+          "available",
+          "target"
+        ],
         "properties": {
-          "id": { "type": "string" },
-          "kind": { "type": "string", "enum": ["comment_reply", "space_moderation", "unavailable"] },
-          "title": { "type": "string" },
-          "description": { "type": "string" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "read_at": { "type": ["string", "null"], "format": "date-time" },
-          "available": { "type": "boolean" },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "comment_reply",
+              "space_moderation",
+              "unavailable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "read_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "available": {
+            "type": "boolean"
+          },
           "target": {
             "anyOf": [
-              { "$ref": "#/components/schemas/NotificationTarget" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/NotificationTarget"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         }
@@ -654,11 +1324,24 @@
       "NotificationCollection": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data", "links", "meta"],
+        "required": [
+          "data",
+          "links",
+          "meta"
+        ],
         "properties": {
-          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Notification" } },
-          "links": { "$ref": "#/components/schemas/PaginationLinks" },
-          "meta": { "$ref": "#/components/schemas/PaginationMeta" }
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Notification"
+            }
+          },
+          "links": {
+            "$ref": "#/components/schemas/PaginationLinks"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
         }
       }
     }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -135,7 +135,7 @@
         "operationId": "getFeed",
         "summary": "Return the member's policy-filtered chronological feed",
         "tags": ["Feed"],
-        "x-lineweb-status": "planned",
+        "x-lineweb-status": "available",
         "x-required-ability": "feed:read",
         "parameters": [
           { "$ref": "#/components/parameters/Cursor" },
@@ -163,6 +163,7 @@
           "401": { "$ref": "#/components/responses/Unauthenticated" },
           "403": { "$ref": "#/components/responses/Forbidden" },
           "404": { "$ref": "#/components/responses/NotFound" },
+          "422": { "$ref": "#/components/responses/ValidationFailed" },
           "429": { "$ref": "#/components/responses/TooManyRequests" }
         }
       }
@@ -231,7 +232,7 @@
         "operationId": "getPostMedia",
         "summary": "Return the authorized normalized post image",
         "tags": ["Posts"],
-        "x-lineweb-status": "planned",
+        "x-lineweb-status": "available",
         "x-required-ability": "feed:read",
         "parameters": [
           { "$ref": "#/components/parameters/PostId" }
@@ -375,6 +376,14 @@
       },
       "NotFound": {
         "description": "The resource does not exist or is not visible to the member.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "ValidationFailed": {
+        "description": "One or more query parameters failed validation.",
         "content": {
           "application/json": {
             "schema": { "$ref": "#/components/schemas/Error" }

--- a/resources/js/components/manage-api-tokens.tsx
+++ b/resources/js/components/manage-api-tokens.tsx
@@ -201,6 +201,24 @@ export default function ManageApiTokens({ apiTokens }: Props) {
                                     </span>
                                 </span>
                             </label>
+                            <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border p-3 transition-colors hover:bg-muted/50">
+                                <input
+                                    type="checkbox"
+                                    name="abilities[]"
+                                    value="feed:read"
+                                    className="mt-0.5 size-4 shrink-0 accent-primary"
+                                />
+                                <span>
+                                    <span className="block text-sm font-medium">
+                                        Policy-filtered feed
+                                    </span>
+                                    <span className="block text-xs text-muted-foreground">
+                                        Read chronological posts and their
+                                        private images only where this account
+                                        already has access.
+                                    </span>
+                                </span>
+                            </label>
                             <InputError message={errors.abilities} />
                         </fieldset>
 

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -7,8 +7,9 @@ import {
     Globe2,
     LockKeyhole,
     MessageCircle,
+    Share2,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import InputError from '@/components/input-error';
 import { AvatarMark } from '@/components/social/avatar-mark';
@@ -25,6 +26,7 @@ import { PostImage } from '@/components/social/post-image';
 import type { PostMedia } from '@/components/social/post-image';
 import { SpaceCover } from '@/components/social/space-cover';
 import { Button } from '@/components/ui/button';
+import { useClipboard } from '@/hooks/use-clipboard';
 
 type ConversationPost = {
     id: number;
@@ -89,6 +91,19 @@ export default function ShowPost({
     status,
 }: ShowPostProps) {
     const [reporting, setReporting] = useState(false);
+    const [copyFeedback, setCopyFeedback] = useState(false);
+    const [copyTimer, setCopyTimer] = useState<number | null>(null);
+    const [, copy] = useClipboard();
+
+    useEffect(
+        () => () => {
+            if (copyTimer !== null) {
+                window.clearTimeout(copyTimer);
+            }
+        },
+        [copyTimer],
+    );
+
     const {
         data,
         setData,
@@ -114,6 +129,24 @@ export default function ShowPost({
 
     const isLatestPage = comments.meta.currentPage === 1;
     const spaceUrl = `/spaces/${encodeURIComponent(post.space.slug)}`;
+
+    const handleCopy = async () => {
+        const copied = await copy(post.url);
+
+        if (!copied) {
+            setCopyFeedback(false);
+
+            return;
+        }
+
+        if (copyTimer !== null) {
+            window.clearTimeout(copyTimer);
+        }
+
+        setCopyFeedback(true);
+        const timer = window.setTimeout(() => setCopyFeedback(false), 2000);
+        setCopyTimer(timer);
+    };
 
     return (
         <>
@@ -207,34 +240,50 @@ export default function ShowPost({
                                             </Link>
                                         </div>
                                     </div>
-                                    {post.hasReported ? (
-                                        <span className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-xl bg-secondary px-3 text-xs font-bold text-muted-foreground">
-                                            <Flag
+                                    <div className="flex shrink-0 flex-wrap items-center gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={handleCopy}
+                                            aria-label="Copy post link"
+                                            className="social-focus inline-flex min-h-9 items-center gap-1.5 rounded-xl px-3 text-xs font-bold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                                        >
+                                            <Share2
                                                 className="size-3.5"
                                                 aria-hidden="true"
                                             />
-                                            Reported
-                                        </span>
-                                    ) : (
-                                        post.canReport && (
-                                            <button
-                                                type="button"
-                                                onClick={() =>
-                                                    setReporting(
-                                                        (open) => !open,
-                                                    )
-                                                }
-                                                aria-expanded={reporting}
-                                                className="social-focus inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-xl px-3 text-xs font-bold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
-                                            >
+                                            {copyFeedback
+                                                ? 'Copied'
+                                                : 'Copy link'}
+                                        </button>
+                                        {post.hasReported ? (
+                                            <span className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-xl bg-secondary px-3 text-xs font-bold text-muted-foreground">
                                                 <Flag
                                                     className="size-3.5"
                                                     aria-hidden="true"
                                                 />
-                                                Report
-                                            </button>
-                                        )
-                                    )}
+                                                Reported
+                                            </span>
+                                        ) : (
+                                            post.canReport && (
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        setReporting(
+                                                            (open) => !open,
+                                                        )
+                                                    }
+                                                    aria-expanded={reporting}
+                                                    className="social-focus inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-xl px-3 text-xs font-bold text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                                                >
+                                                    <Flag
+                                                        className="size-3.5"
+                                                        aria-hidden="true"
+                                                    />
+                                                    Report
+                                                </button>
+                                            )
+                                        )}
+                                    </div>
                                 </header>
 
                                 <p className="mt-5 text-[1.04rem] leading-8 whitespace-pre-wrap text-foreground/92">

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,9 @@
 
 use App\Http\Controllers\Api\V1\CurrentProfileController;
 use App\Http\Controllers\Api\V1\FeedController;
+use App\Http\Controllers\Api\V1\NotificationController;
+use App\Http\Controllers\Api\V1\PostCommentController;
+use App\Http\Controllers\Api\V1\PostController;
 use App\Http\Controllers\Api\V1\PostMediaController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\SpaceController;
@@ -37,4 +40,19 @@ Route::prefix('v1')
         Route::get('posts/{post}/media', PostMediaController::class)
             ->middleware('abilities:feed:read')
             ->name('api.v1.posts.media');
+        Route::get('posts/{post}', PostController::class)
+            ->middleware('abilities:feed:read')
+            ->name('api.v1.posts.show');
+        Route::get('posts/{post}/comments', PostCommentController::class)
+            ->middleware('abilities:feed:read')
+            ->name('api.v1.posts.comments');
+        Route::get('notifications', NotificationController::class)
+            ->middleware('abilities:notifications:read')
+            ->name('api.v1.notifications');
+        Route::patch('notifications/read-all', [NotificationController::class, 'readAll'])
+            ->middleware('abilities:notifications:write')
+            ->name('api.v1.notifications.read-all');
+        Route::patch('notifications/{notification}/read', [NotificationController::class, 'readOne'])
+            ->middleware('abilities:notifications:write')
+            ->name('api.v1.notifications.read');
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\Api\V1\CurrentProfileController;
+use App\Http\Controllers\Api\V1\FeedController;
+use App\Http\Controllers\Api\V1\PostMediaController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\SpaceController;
 use App\Http\Controllers\Api\V1\SpaceIndexController;
@@ -29,4 +31,10 @@ Route::prefix('v1')
         Route::get('spaces/{space:slug}', SpaceController::class)
             ->middleware('abilities:spaces:read')
             ->name('api.v1.spaces.show');
+        Route::get('feed', FeedController::class)
+            ->middleware('abilities:feed:read')
+            ->name('api.v1.feed');
+        Route::get('posts/{post}/media', PostMediaController::class)
+            ->middleware('abilities:feed:read')
+            ->name('api.v1.posts.media');
     });

--- a/tests/Feature/Api/FeedTest.php
+++ b/tests/Feature/Api/FeedTest.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Enums\ProfileVisibility;
+use App\Enums\UserRelationshipType;
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\PostReport;
+use App\Models\Space;
+use App\Models\User;
+use App\Models\UserRelationship;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FeedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('media');
+    }
+
+    public function test_feed_returns_only_policy_visible_posts_in_the_safe_public_contract(): void
+    {
+        $viewer = User::factory()->create();
+        $publicAuthor = User::factory()->create([
+            'headline' => 'Public-space author',
+            'profile_visibility' => ProfileVisibility::Private,
+        ]);
+        $privateAuthor = User::factory()->create([
+            'headline' => 'Member-space author',
+            'profile_visibility' => ProfileVisibility::Members,
+        ]);
+        $mutedAuthor = User::factory()->create();
+        $blockingAuthor = User::factory()->create();
+        $visibleCommenter = User::factory()->create();
+        $mutedCommenter = User::factory()->create();
+        $public = Space::factory()->for($publicAuthor, 'owner')->create();
+        $private = Space::factory()->for($privateAuthor, 'owner')->private()->create();
+        $inaccessible = Space::factory()->private()->create();
+        $private->addMember($viewer);
+
+        $olderPublic = Post::factory()->for($public)->for($publicAuthor, 'author')->create([
+            'body' => 'Older public post',
+            'published_at' => now()->subMinutes(2),
+        ]);
+        $newerPrivate = Post::factory()->for($private)->for($privateAuthor, 'author')->create([
+            'body' => 'Newer private-member post',
+            'published_at' => now()->subMinute(),
+        ]);
+
+        Comment::factory()->for($olderPublic)->for($visibleCommenter, 'author')->create();
+        Comment::factory()->for($olderPublic)->for($mutedCommenter, 'author')->create();
+        Comment::factory()->for($olderPublic)->for($visibleCommenter, 'author')->create([
+            'hidden_at' => now(),
+        ]);
+        PostReport::factory()->create([
+            'post_id' => $olderPublic->getKey(),
+            'reporter_id' => $viewer->getKey(),
+        ]);
+
+        Post::factory()->for($public)->for($publicAuthor, 'author')->create([
+            'body' => 'Draft post',
+            'published_at' => null,
+        ]);
+        Post::factory()->for($public)->for($publicAuthor, 'author')->create([
+            'body' => 'Moderated post',
+            'hidden_at' => now(),
+        ]);
+        Post::factory()->for($inaccessible)->create(['body' => 'Private outsider post']);
+        Post::factory()->for($public)->for($mutedAuthor, 'author')->create(['body' => 'Muted post']);
+        Post::factory()->for($public)->for($blockingAuthor, 'author')->create(['body' => 'Blocking post']);
+
+        $viewer->outgoingRelationships()->create([
+            'target_id' => $mutedAuthor->getKey(),
+            'type' => UserRelationshipType::Mute,
+        ]);
+        $viewer->outgoingRelationships()->create([
+            'target_id' => $mutedCommenter->getKey(),
+            'type' => UserRelationshipType::Mute,
+        ]);
+        $blockingAuthor->outgoingRelationships()->create([
+            'target_id' => $viewer->getKey(),
+            'type' => UserRelationshipType::Block,
+        ]);
+
+        $response = $this->withToken($this->token($viewer))->getJson(route('api.v1.feed'));
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('meta.limit', 20)
+            ->assertJsonPath('meta.has_more', false)
+            ->assertJsonPath('links.next', null)
+            ->assertJsonPath('data.0.id', (string) $newerPrivate->getKey())
+            ->assertJsonPath('data.0.viewer.can_comment', true)
+            ->assertJsonPath('data.0.author.profile_visible', true)
+            ->assertJsonPath('data.0.space.slug', $private->slug)
+            ->assertJsonPath('data.0.space.viewer.is_member', true)
+            ->assertJsonPath('data.1.id', (string) $olderPublic->getKey())
+            ->assertJsonPath('data.1.comments_count', 1)
+            ->assertJsonPath('data.1.author.profile_visible', false)
+            ->assertJsonPath('data.1.viewer.can_comment', false)
+            ->assertJsonPath('data.1.viewer.can_report', true)
+            ->assertJsonPath('data.1.viewer.has_reported', true)
+            ->assertJsonCount(2, 'data')
+            ->assertJsonMissing(['body' => 'Draft post'])
+            ->assertJsonMissing(['body' => 'Moderated post'])
+            ->assertJsonMissing(['body' => 'Private outsider post'])
+            ->assertJsonMissing(['body' => 'Muted post'])
+            ->assertJsonMissing(['body' => 'Blocking post'])
+            ->assertJsonMissingPath('data.0.hidden_at')
+            ->assertJsonMissingPath('data.0.moderation_note')
+            ->assertJsonMissingPath('data.0.author.id')
+            ->assertHeader('X-RateLimit-Limit', '120');
+
+        $this->assertSame(
+            ['id', 'body', 'published_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            array_keys($response->json('data.0')),
+        );
+        $this->assertSame(
+            ['handle', 'name', 'headline', 'profile_visible'],
+            array_keys($response->json('data.0.author')),
+        );
+    }
+
+    public function test_feed_cursor_is_deterministic_opaque_and_bound_to_viewer_and_filter(): void
+    {
+        $this->freezeTime();
+        $viewer = User::factory()->create();
+        $otherViewer = User::factory()->create();
+        $author = User::factory()->create();
+        $firstSpace = Space::factory()->for($author, 'owner')->create(['slug' => 'first-space']);
+        $secondSpace = Space::factory()->for($author, 'owner')->create(['slug' => 'second-space']);
+        $first = Post::factory()->for($firstSpace)->for($author, 'author')->create(['published_at' => now()]);
+        $second = Post::factory()->for($firstSpace)->for($author, 'author')->create(['published_at' => now()]);
+        $third = Post::factory()->for($firstSpace)->for($author, 'author')->create(['published_at' => now()]);
+
+        $pageOne = $this->withToken($this->token($viewer))->getJson(route('api.v1.feed', [
+            'space' => $firstSpace->slug,
+            'limit' => 2,
+        ]));
+
+        $pageOne
+            ->assertOk()
+            ->assertJsonPath('meta.has_more', true)
+            ->assertJsonPath('data.0.id', (string) $third->getKey())
+            ->assertJsonPath('data.1.id', (string) $second->getKey());
+
+        $cursor = $pageOne->json('meta.next_cursor');
+        $this->assertIsString($cursor);
+        $this->assertStringNotContainsString('viewer_id', $cursor);
+
+        $pageTwo = $this->withToken($this->token($viewer))->getJson(route('api.v1.feed', [
+            'space' => $firstSpace->slug,
+            'limit' => 2,
+            'cursor' => $cursor,
+        ]));
+
+        $pageTwo
+            ->assertOk()
+            ->assertJsonPath('meta.has_more', false)
+            ->assertJsonPath('data.0.id', (string) $first->getKey())
+            ->assertJsonCount(1, 'data');
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.feed', [
+                'space' => $firstSpace->slug,
+                'cursor' => $cursor.'tampered',
+            ]))
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+
+        $this->withToken($this->token($otherViewer))
+            ->getJson(route('api.v1.feed', [
+                'space' => $firstSpace->slug,
+                'cursor' => $cursor,
+            ]))
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.feed', [
+                'space' => $secondSpace->slug,
+                'cursor' => $cursor,
+            ]))
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+
+        foreach ([0, 51] as $limit) {
+            $this->withToken($this->token($viewer))
+                ->getJson(route('api.v1.feed', ['limit' => $limit]))
+                ->assertUnprocessable()
+                ->assertJsonPath('code', 'validation_failed');
+        }
+    }
+
+    public function test_feed_requires_its_scope_and_hides_inaccessible_space_filters(): void
+    {
+        $viewer = User::factory()->create();
+        $unverified = User::factory()->unverified()->create();
+        $public = Space::factory()->create(['slug' => 'visible-space']);
+        $private = Space::factory()->private()->create(['slug' => 'private-space']);
+        $visiblePost = Post::factory()->for($public)->create();
+        Post::factory()->for($private)->create();
+
+        $this->withToken($this->token($viewer, ['profile:read']))
+            ->getJson(route('api.v1.feed'))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+
+        $this->withToken($this->token($unverified))
+            ->getJson(route('api.v1.feed'))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.feed', ['space' => $private->slug]))
+            ->assertNotFound()
+            ->assertJsonPath('code', 'not_found');
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.feed', ['space' => $public->slug]))
+            ->assertOk()
+            ->assertJsonPath('data.0.id', (string) $visiblePost->getKey())
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_feed_media_uses_bearer_authorization_and_never_exposes_storage_metadata(): void
+    {
+        $viewer = User::factory()->create();
+        $outsider = User::factory()->create();
+        $author = User::factory()->create();
+        $space = Space::factory()->for($author, 'owner')->private()->create();
+        $space->addMember($viewer);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+        $contents = 'safe-private-webp-contents';
+        $path = 'posts/feed-image.webp';
+        Storage::disk('media')->put($path, $contents);
+        $media = $post->media()->create([
+            'disk' => 'media',
+            'path' => $path,
+            'mime_type' => 'image/webp',
+            'width' => 1280,
+            'height' => 720,
+            'size_bytes' => strlen($contents),
+            'checksum' => hash('sha256', $contents),
+            'alt_text' => 'A community workshop in progress.',
+        ]);
+        $token = $this->token($viewer);
+
+        $feed = $this->withToken($token)->getJson(route('api.v1.feed'));
+
+        $feed
+            ->assertOk()
+            ->assertJsonPath('data.0.media.url', route('api.v1.posts.media', $post))
+            ->assertJsonPath('data.0.media.alt', 'A community workshop in progress.')
+            ->assertJsonPath('data.0.media.mime_type', 'image/webp')
+            ->assertJsonMissingPath('data.0.media.disk')
+            ->assertJsonMissingPath('data.0.media.path')
+            ->assertJsonMissingPath('data.0.media.checksum')
+            ->assertJsonMissingPath('data.0.media.size_bytes');
+
+        $response = $this->withToken($token)->get(route('api.v1.posts.media', $post));
+
+        $response
+            ->assertOk()
+            ->assertHeader('Content-Type', 'image/webp')
+            ->assertHeader('Content-Disposition', 'inline; filename="post-image.webp"')
+            ->assertHeader('X-Content-Type-Options', 'nosniff')
+            ->assertHeader('Cross-Origin-Resource-Policy', 'same-site')
+            ->assertHeader('ETag', '"'.$media->checksum.'"')
+            ->assertContent($contents);
+        $this->assertStringContainsString('private', (string) $response->headers->get('Cache-Control'));
+        $this->assertStringContainsString('Authorization', (string) $response->headers->get('Vary'));
+
+        $this->withToken($this->token($viewer, ['profile:read']))
+            ->get(route('api.v1.posts.media', $post))
+            ->assertForbidden();
+
+        $this->withToken($this->token($viewer, ['profile:read']))
+            ->get(route('api.v1.posts.media', 999999))
+            ->assertForbidden();
+
+        $this->withToken($this->token($outsider))
+            ->get(route('api.v1.posts.media', $post))
+            ->assertNotFound();
+
+        UserRelationship::query()->create([
+            'actor_id' => $viewer->getKey(),
+            'target_id' => $author->getKey(),
+            'type' => UserRelationshipType::Mute,
+        ]);
+
+        $this->app['auth']->forgetGuards();
+        $this->withToken($token)
+            ->get(route('api.v1.posts.media', $post))
+            ->assertNotFound();
+
+        UserRelationship::query()->delete();
+        Storage::disk('media')->delete($path);
+
+        $this->withToken($token)
+            ->get(route('api.v1.posts.media', $post))
+            ->assertNotFound();
+    }
+
+    /** @param list<string> $abilities */
+    private function token(User $user, array $abilities = ['feed:read']): string
+    {
+        // Sanctum's guard caches the authenticated user for the current process.
+        // Feature tests make several simulated requests with different tokens.
+        $this->app['auth']->forgetGuards();
+
+        return $user->createToken('Feed API test', $abilities, now()->addDays(30))->plainTextToken;
+    }
+}

--- a/tests/Feature/Api/NotificationApiTest.php
+++ b/tests/Feature/Api/NotificationApiTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\PostReport;
+use App\Models\Space;
+use App\Models\User;
+use App\Notifications\CommentReplyNotification;
+use App\Notifications\SpaceModerationNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Tests\TestCase;
+
+class NotificationApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_notifications_returns_safe_projection_with_cursor_and_filters(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create();
+        $space = Space::factory()->for($viewer, 'owner')->create();
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+        $comment = Comment::factory()->for($post)->for($author, 'author')->create();
+
+        $this->travelTo(now()->subMinute());
+        $viewer->notify(new CommentReplyNotification($comment));
+
+        $this->travel(1)->second();
+        $report = PostReport::factory()->create([
+            'post_id' => $post->getKey(),
+            'reporter_id' => $author->getKey(),
+        ]);
+        $viewer->notify(new SpaceModerationNotification($space->getKey(), 'post', $report->getKey()));
+
+        $ordered = DatabaseNotification::query()
+            ->where('notifiable_type', $viewer->getMorphClass())
+            ->where('notifiable_id', $viewer->getKey())
+            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->get();
+        $orderedIds = $ordered->pluck('id')->all();
+
+        $firstUnread = $ordered->first();
+        $secondUnread = $ordered->get(1);
+
+        $this->assertNotNull($firstUnread);
+        $this->assertNotNull($secondUnread);
+
+        $pageOne = $this->withToken($this->token($viewer))->getJson(route('api.v1.notifications', ['limit' => 1]));
+
+        $pageOne
+            ->assertOk()
+            ->assertJsonPath('meta.limit', 1)
+            ->assertJsonPath('meta.has_more', true)
+            ->assertJsonPath('data.0.id', (string) $firstUnread->getKey())
+            ->assertJsonPath('data.0.available', true)
+            ->assertJsonPath('data.0.title', fn (string $title) => is_string($title) && $title !== '')
+            ->assertJsonPath('data.0.target', fn ($target) => is_array($target))
+            ->assertJsonPath('data.0.target.type', 'space_moderation')
+            ->assertJsonPath('data.0.target.space_slug', $space->slug)
+            ->assertJsonPath('data.0.read_at', null)
+            ->assertJsonPath('links.next', fn (?string $url): bool => is_string($url) && str_contains($url, 'cursor='));
+
+        $cursor = $pageOne->json('meta.next_cursor');
+        $this->assertIsString($cursor);
+
+        $pageTwo = $this->withToken($this->token($viewer))->getJson(route('api.v1.notifications', [
+            'limit' => 1,
+            'cursor' => $cursor,
+        ]));
+
+        $pageTwo
+            ->assertOk()
+            ->assertJsonPath('meta.has_more', false)
+            ->assertJsonPath('data.0.id', (string) $secondUnread->getKey())
+            ->assertJsonPath('data.0.target.type', 'post')
+            ->assertJsonPath('data.0.target.post_id', (string) $post->getKey())
+            ->assertJsonPath('data.0.target.comment_id', (string) $comment->getKey())
+            ->assertJsonPath('links.next', null);
+
+        $firstUnread->update(['read_at' => now()]);
+
+        $unread = $this->withToken($this->token($viewer))->getJson(route('api.v1.notifications', ['filter' => 'unread']));
+
+        $unread
+            ->assertOk()
+            ->assertJsonPath('meta.has_more', false)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', (string) $secondUnread->getKey());
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.notifications', ['cursor' => $cursor.'tampered']))
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+
+        $otherViewer = User::factory()->create();
+        $this->withToken($this->token($otherViewer))
+            ->getJson(route('api.v1.notifications', ['cursor' => $cursor]))
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.notifications', ['cursor' => $cursor, 'filter' => 'unread']))
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+    }
+
+    public function test_notifications_write_endpoints_mark_one_and_all_read(): void
+    {
+        $viewer = User::factory()->create();
+        $otherViewer = User::factory()->create();
+        $author = User::factory()->create();
+        $space = Space::factory()->for($viewer, 'owner')->create();
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+        $comment = Comment::factory()->for($post)->for($author, 'author')->create();
+
+        $viewer->notify(new CommentReplyNotification($comment));
+        $viewer->notify(new CommentReplyNotification($comment));
+
+        $ordered = DatabaseNotification::query()
+            ->where('notifiable_type', $viewer->getMorphClass())
+            ->where('notifiable_id', $viewer->getKey())
+            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->get();
+
+        $latest = $ordered->first();
+        $this->assertNotNull($latest);
+
+        $this->withToken($this->token($viewer))
+            ->patchJson(route('api.v1.notifications.read', ['notification' => $latest->getKey()]))
+            ->assertStatus(403)
+            ->assertJsonPath('code', 'forbidden');
+
+        $this->withToken($this->token($otherViewer, ['notifications:write']))
+            ->patchJson(route('api.v1.notifications.read', ['notification' => $latest->getKey()]))
+            ->assertNotFound()
+            ->assertJsonPath('code', 'not_found');
+
+        $writeToken = $this->token($viewer, ['notifications:write']);
+        $this->withToken($writeToken)
+            ->patchJson(route('api.v1.notifications.read', ['notification' => $latest->getKey()]))
+            ->assertStatus(204);
+
+        $this->assertNotNull($latest->refresh()->read_at);
+
+        $this->withToken($writeToken)
+            ->patchJson(route('api.v1.notifications.read-all'))
+            ->assertStatus(204);
+
+        $this->assertDatabaseMissing('notifications', [
+            'notifiable_id' => $viewer->getKey(),
+            'read_at' => null,
+        ]);
+    }
+
+    public function test_notifications_require_scope_and_verified_access(): void
+    {
+        $viewer = User::factory()->create();
+        $unverified = User::factory()->unverified()->create();
+
+        $this->withToken($this->token($viewer, ['profile:read']))
+            ->getJson(route('api.v1.notifications'))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+
+        $this->withToken($this->token($unverified))
+            ->getJson(route('api.v1.notifications'))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+
+        $this->withoutToken()
+            ->getJson(route('api.v1.notifications'))
+            ->assertUnauthorized()
+            ->assertJsonPath('code', 'unauthenticated');
+
+        $this->withToken($this->token($viewer, ['notifications:read']))
+            ->getJson(route('api.v1.notifications', ['filter' => 'maybe']))
+            ->assertUnprocessable()
+            ->assertJsonPath('code', 'validation_failed');
+    }
+
+    /** @param list<string> $abilities */
+    private function token(User $user, array $abilities = ['notifications:read']): string
+    {
+        $this->app['auth']->forgetGuards();
+
+        return $user->createToken('Notification API test', $abilities, now()->addDays(30))->plainTextToken;
+    }
+}

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Enums\ProfileVisibility;
+use App\Enums\UserRelationshipType;
+use App\Models\Comment;
+use App\Models\CommentReport;
+use App\Models\Post;
+use App\Models\PostReport;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PostApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_post_detail_returns_the_safe_visible_projection_and_viewer_state(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create([
+            'name' => 'Post Author',
+            'headline' => 'Platform architect',
+            'profile_visibility' => ProfileVisibility::Members,
+        ]);
+        $space = Space::factory()->for($author, 'owner')->create();
+        $space->addMember($viewer);
+        $post = Post::factory()->for($space)->for($author, 'author')->create([
+            'body' => 'A stable post for API readers.',
+        ]);
+
+        Storage::fake('media');
+        $mediaPath = 'posts/post-media.webp';
+        $mediaContents = 'api-safe-webp';
+        Storage::disk('media')->put($mediaPath, $mediaContents);
+        $media = $post->media()->create([
+            'disk' => 'media',
+            'path' => $mediaPath,
+            'mime_type' => 'image/webp',
+            'width' => 1280,
+            'height' => 720,
+            'size_bytes' => strlen($mediaContents),
+            'checksum' => hash('sha256', $mediaContents),
+            'alt_text' => 'A clean API image.',
+        ]);
+
+        Comment::factory()->for($post)->for($viewer, 'author')->create(['body' => 'Visible comment']);
+        $muted = User::factory()->create();
+        $blocking = User::factory()->create();
+
+        $viewer->outgoingRelationships()->create([
+            'target_id' => $muted->getKey(),
+            'type' => UserRelationshipType::Mute->value,
+        ]);
+        $viewer->outgoingRelationships()->create([
+            'target_id' => $blocking->getKey(),
+            'type' => UserRelationshipType::Block->value,
+        ]);
+
+        Comment::factory()->for($post)->for($muted, 'author')->create(['body' => 'Muted comment']);
+        Comment::factory()->for($post)->for($blocking, 'author')->create(['body' => 'Blocking comment']);
+
+        PostReport::factory()->create([
+            'post_id' => $post->getKey(),
+            'reporter_id' => $viewer->getKey(),
+        ]);
+
+        $response = $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.show', $post));
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.id', (string) $post->getKey())
+            ->assertJsonPath('data.body', 'A stable post for API readers.')
+            ->assertJsonPath('data.comments_count', 1)
+            ->assertJsonPath('data.author.profile_visible', true)
+            ->assertJsonPath('data.space.slug', $space->slug)
+            ->assertJsonPath('data.viewer.can_comment', true)
+            ->assertJsonPath('data.viewer.can_report', true)
+            ->assertJsonPath('data.viewer.has_reported', true)
+            ->assertJsonPath('data.media.url', route('api.v1.posts.media', $post))
+            ->assertJsonPath('data.media.alt', $media->alt_text)
+            ->assertJsonMissingPath('data.media.disk')
+            ->assertJsonMissingPath('data.media.path')
+            ->assertJsonMissingPath('data.media.checksum')
+            ->assertJsonMissingPath('data.media.size_bytes')
+            ->assertJsonMissingPath('data.media.owner_id')
+            ->assertJsonMissingPath('data.media.author_id');
+
+        $this->assertSame(
+            ['id', 'body', 'published_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            array_keys($response->json('data')),
+        );
+        $this->assertSame(
+            ['handle', 'name', 'headline', 'profile_visible'],
+            array_keys($response->json('data.author')),
+        );
+    }
+
+    public function test_post_endpoints_require_scope_and_visibility_boundaries(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create();
+        $public = Space::factory()->create();
+        $private = Space::factory()->private()->create();
+        $publicPost = Post::factory()->for($public)->for($author, 'author')->create();
+        $privatePost = Post::factory()->for($private)->for($author, 'author')->create();
+        $hiddenPost = Post::factory()->for($public)->for($author, 'author')->create([
+            'hidden_at' => now(),
+            'body' => 'Moderated post',
+        ]);
+        $draftPost = Post::factory()->for($public)->for($author, 'author')->create([
+            'published_at' => null,
+            'body' => 'Draft post',
+        ]);
+
+        $this->getWithToken($viewer, ['spaces:read'])
+            ->getJson(route('api.v1.posts.show', $publicPost))
+            ->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+
+        $privateResponse = $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.show', $privatePost));
+        $privateResponse
+            ->assertNotFound()
+            ->assertJsonPath('code', 'not_found');
+
+        $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.show', $hiddenPost))
+            ->assertNotFound();
+
+        $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.show', $draftPost))
+            ->assertNotFound();
+
+        $this->getWithToken($viewer, ['profile:read'])
+            ->getJson(route('api.v1.posts.show', $publicPost))
+            ->assertForbidden();
+
+        $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.show', 999999))
+            ->assertNotFound();
+    }
+
+    public function test_post_comments_are_visible_in_chronological_pages_and_filter_muted_blocked_hidden_comments(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create();
+        $mutedAuthor = User::factory()->create();
+        $blockingAuthor = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($viewer);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+
+        Comment::factory()->for($post)->for($author, 'author')->create([
+            'body' => 'Visible 1',
+            'published_at' => now()->subMinutes(3),
+        ]);
+        $reported = Comment::factory()->for($post)->for($author, 'author')->create([
+            'body' => 'Visible 2',
+            'published_at' => now()->subMinutes(2),
+        ]);
+        Comment::factory()->for($post)->for($author, 'author')->create([
+            'body' => 'Visible 3',
+            'published_at' => now()->subMinutes(1),
+        ]);
+        Comment::factory()->for($post)->for($mutedAuthor, 'author')->create([
+            'body' => 'Muted comment',
+            'published_at' => now(),
+        ]);
+        Comment::factory()->for($post)->for($blockingAuthor, 'author')->create([
+            'body' => 'Blocking comment',
+            'published_at' => now()->addMinute(),
+        ]);
+        Comment::factory()->for($post)->for($author, 'author')->create([
+            'body' => 'Hidden comment',
+            'published_at' => now()->addMinutes(2),
+            'hidden_at' => now(),
+        ]);
+
+        CommentReport::factory()->create([
+            'comment_id' => $reported->getKey(),
+            'reporter_id' => $viewer->getKey(),
+        ]);
+
+        $viewer->outgoingRelationships()->create([
+            'target_id' => $mutedAuthor->getKey(),
+            'type' => UserRelationshipType::Mute->value,
+        ]);
+        $blockingAuthor->outgoingRelationships()->create([
+            'target_id' => $viewer->getKey(),
+            'type' => UserRelationshipType::Block->value,
+        ]);
+
+        $pageOne = $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.comments', [
+                'post' => $post,
+                'limit' => 2,
+            ]));
+
+        $pageOne
+            ->assertOk()
+            ->assertJsonPath('meta.limit', 2)
+            ->assertJsonPath('meta.has_more', true)
+            ->assertJsonPath('links.next', fn (?string $url): bool => is_string($url) && str_contains($url, 'cursor='))
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.id', (string) $post->comments()->orderBy('published_at')->first()->getKey())
+            ->assertJsonPath('data.1.id', (string) $reported->getKey())
+            ->assertJsonPath('data.1.viewer.can_report', true)
+            ->assertJsonPath('data.1.viewer.has_reported', true)
+            ->assertJsonMissing(['body' => 'Muted comment'])
+            ->assertJsonMissing(['body' => 'Blocking comment'])
+            ->assertJsonMissing(['body' => 'Hidden comment']);
+
+        $cursor = $pageOne->json('meta.next_cursor');
+        $this->assertIsString($cursor);
+
+        $pageTwo = $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.comments', [
+                'post' => $post,
+                'limit' => 2,
+                'cursor' => $cursor,
+            ]));
+
+        $pageTwo
+            ->assertOk()
+            ->assertJsonPath('meta.has_more', false)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', (string) Comment::query()
+                ->where('post_id', $post->getKey())
+                ->where('body', 'Visible 3')
+                ->firstOrFail()
+                ->getKey())
+            ->assertJsonPath('links.next', null);
+
+        $tampered = $cursor.'tampered';
+        $invalidCursorResponse = $this->getWithToken($viewer)
+            ->getJson(route('api.v1.posts.comments', [
+                'post' => $post,
+                'cursor' => $tampered,
+            ]));
+        $invalidCursorResponse
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+
+        $otherViewer = User::factory()->create();
+        $invalidViewerResponse = $this->getWithToken($otherViewer)
+            ->getJson(route('api.v1.posts.comments', [
+                'post' => $post,
+                'cursor' => $cursor,
+            ]));
+        $invalidViewerResponse
+            ->assertBadRequest()
+            ->assertJsonPath('code', 'invalid_cursor');
+
+        foreach ([0, 51] as $limit) {
+            $this->getWithToken($viewer)
+                ->getJson(route('api.v1.posts.comments', [
+                    'post' => $post,
+                    'limit' => $limit,
+                ]))
+                ->assertUnprocessable()
+                ->assertJsonPath('code', 'validation_failed');
+        }
+    }
+
+    /** @param list<string> $abilities */
+    private function getWithToken(User $user, array $abilities = ['feed:read']): self
+    {
+        return $this
+            ->withHeaders([
+                'Authorization' => 'Bearer '.$this->token($user, $abilities),
+                'Accept' => 'application/json',
+            ]);
+    }
+
+    private function token(User $user, array $abilities = ['feed:read']): string
+    {
+        $this->app['auth']->forgetGuards();
+
+        return $user->createToken('Post API test', $abilities, now()->addDays(30))->plainTextToken;
+    }
+}

--- a/tests/Feature/Settings/ApiTokenManagementTest.php
+++ b/tests/Feature/Settings/ApiTokenManagementTest.php
@@ -59,7 +59,7 @@ class ApiTokenManagementTest extends TestCase
             ->from(route('security.edit'))
             ->post(route('api-tokens.store'), [
                 'name' => '  My phone  ',
-                'abilities' => ['profile:read', 'profiles:read', 'spaces:read'],
+                'abilities' => ['profile:read', 'profiles:read', 'spaces:read', 'feed:read'],
             ]);
 
         $response
@@ -70,7 +70,10 @@ class ApiTokenManagementTest extends TestCase
         $flash = $response->getSession()->get(SessionKey::FLASH_DATA);
 
         $this->assertSame('My phone', $token->name);
-        $this->assertSame(['profile:read', 'profiles:read', 'spaces:read'], $token->abilities);
+        $this->assertSame(
+            ['profile:read', 'profiles:read', 'spaces:read', 'feed:read'],
+            $token->abilities,
+        );
         $this->assertSame(now()->addDays(30)->timestamp, $token->expires_at?->timestamp);
         $this->assertIsArray($flash);
         $this->assertSame('My phone', $flash['apiToken']['name']);
@@ -128,6 +131,14 @@ class ApiTokenManagementTest extends TestCase
             ->withSession(['auth.password_confirmed_at' => time()])
             ->post(route('api-tokens.store'), [
                 'name' => 'Missing abilities',
+            ])
+            ->assertSessionHasErrors('abilities');
+
+        $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->post(route('api-tokens.store'), [
+                'name' => 'Feed without own profile',
+                'abilities' => ['feed:read'],
             ])
             ->assertSessionHasErrors('abilities');
 

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -24,10 +24,24 @@ class ApiContractDocumentationTest extends TestCase
     /**
      * @throws JsonException
      */
-    public function test_first_contract_is_read_only_and_only_implemented_read_operations_are_available(): void
+    public function test_contract_is_available_for_only_implemented_operations(): void
     {
         $contract = $this->contract();
         $expectedPaths = [
+            '/feed',
+            '/me',
+            '/notifications',
+            '/notifications/read-all',
+            '/notifications/{notification}/read',
+            '/posts/{post}',
+            '/posts/{post}/comments',
+            '/posts/{post}/media',
+            '/profiles/{handle}',
+            '/spaces',
+            '/spaces/{slug}',
+        ];
+        $paths = array_keys($contract['paths']);
+        $availableGetPaths = [
             '/feed',
             '/me',
             '/notifications',
@@ -38,14 +52,9 @@ class ApiContractDocumentationTest extends TestCase
             '/spaces',
             '/spaces/{slug}',
         ];
-        $paths = array_keys($contract['paths']);
-        $availablePaths = [
-            '/feed',
-            '/me',
-            '/posts/{post}/media',
-            '/profiles/{handle}',
-            '/spaces',
-            '/spaces/{slug}',
+        $availablePatchPaths = [
+            '/notifications/{notification}/read',
+            '/notifications/read-all',
         ];
 
         sort($paths);
@@ -53,16 +62,26 @@ class ApiContractDocumentationTest extends TestCase
         $this->assertSame($expectedPaths, $paths);
 
         foreach ($contract['paths'] as $path => $pathItem) {
+            $methods = array_keys($pathItem);
+            $availableMethods = in_array($path, $availableGetPaths, true)
+                ? ['get']
+                : ['patch'];
+
             $this->assertSame(
-                ['get'],
-                array_keys($pathItem),
-                $path.' must remain read-only in the first contract slice.',
+                $availableMethods,
+                $methods,
+                $path.' methods must match the implemented slice.',
             );
-            $this->assertSame(
-                in_array($path, $availablePaths, true) ? 'available' : 'planned',
-                $pathItem['get']['x-lineweb-status'],
-            );
-            $this->assertArrayNotHasKey('requestBody', $pathItem['get']);
+
+            foreach ($methods as $method) {
+                $operation = $pathItem[$method];
+                $isAvailable = in_array($path, [...$availableGetPaths, ...$availablePatchPaths], true);
+                $this->assertSame(
+                    $isAvailable ? 'available' : 'planned',
+                    $operation['x-lineweb-status'],
+                );
+                $this->assertArrayNotHasKey('requestBody', $operation);
+            }
         }
 
         $this->assertArrayHasKey('422', $contract['paths']['/feed']['get']['responses']);
@@ -80,15 +99,16 @@ class ApiContractDocumentationTest extends TestCase
             'spaces:read',
             'feed:read',
             'notifications:read',
+            'notifications:write',
         ];
 
         foreach ($contract['paths'] as $path => $pathItem) {
-            $operation = $pathItem['get'];
-
-            $this->assertContains($operation['x-required-ability'], $allowedAbilities);
-            $this->assertArrayHasKey('401', $operation['responses'], $path);
-            $this->assertArrayHasKey('403', $operation['responses'], $path);
-            $this->assertArrayHasKey('429', $operation['responses'], $path);
+            foreach ($pathItem as $method => $operation) {
+                $this->assertContains($operation['x-required-ability'], $allowedAbilities, $path.' '.$method);
+                $this->assertArrayHasKey('401', $operation['responses'], $path.' '.$method);
+                $this->assertArrayHasKey('403', $operation['responses'], $path.' '.$method);
+                $this->assertArrayHasKey('429', $operation['responses'], $path.' '.$method);
+            }
         }
 
         $throttleHeaders = $contract['components']['responses']['TooManyRequests']['headers'];

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -39,6 +39,14 @@ class ApiContractDocumentationTest extends TestCase
             '/spaces/{slug}',
         ];
         $paths = array_keys($contract['paths']);
+        $availablePaths = [
+            '/feed',
+            '/me',
+            '/posts/{post}/media',
+            '/profiles/{handle}',
+            '/spaces',
+            '/spaces/{slug}',
+        ];
 
         sort($paths);
 
@@ -51,11 +59,13 @@ class ApiContractDocumentationTest extends TestCase
                 $path.' must remain read-only in the first contract slice.',
             );
             $this->assertSame(
-                in_array($path, ['/me', '/profiles/{handle}', '/spaces', '/spaces/{slug}'], true) ? 'available' : 'planned',
+                in_array($path, $availablePaths, true) ? 'available' : 'planned',
                 $pathItem['get']['x-lineweb-status'],
             );
             $this->assertArrayNotHasKey('requestBody', $pathItem['get']);
         }
+
+        $this->assertArrayHasKey('422', $contract['paths']['/feed']['get']['responses']);
     }
 
     /**
@@ -112,11 +122,21 @@ class ApiContractDocumentationTest extends TestCase
             ['slug', 'name', 'description', 'visibility', 'member_count', 'viewer'],
             array_keys($schemas['Space']['properties']),
         );
+        $this->assertSame(
+            ['id', 'body', 'published_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            array_keys($schemas['Post']['properties']),
+        );
+        $this->assertSame(
+            ['handle', 'name', 'headline', 'profile_visible'],
+            array_keys($schemas['ProfileSummary']['properties']),
+        );
 
         foreach (['email', 'password', 'token', 'disk', 'path', 'checksum', 'data'] as $forbidden) {
             $this->assertArrayNotHasKey($forbidden, $schemas['Profile']['properties']);
             $this->assertArrayNotHasKey($forbidden, $schemas['Space']['properties']);
             $this->assertArrayNotHasKey($forbidden, $schemas['Media']['properties']);
+            $this->assertArrayNotHasKey($forbidden, $schemas['Post']['properties']);
+            $this->assertArrayNotHasKey($forbidden, $schemas['ProfileSummary']['properties']);
             $this->assertArrayNotHasKey($forbidden, $schemas['Notification']['properties']);
         }
     }


### PR DESCRIPTION
## Why
We needed a read-only content feed endpoint for native clients and public integrations without bypassing existing privacy and moderation rules.

## What changed
- Add policy-filtered `GET /api/v1/feed` with hidden-space exclusions, muted/blocked user filtering, discoverability checks, cursor-based pagination, and safe ordering.
- Add viewer-bound encrypted cursor handling in `FeedCursor` with dedicated validation and robust error behavior.
- Add `feed:read` token scope and ensure API token UX requires `profile:read` as needed.
- Add secure `GET /api/v1/posts/{post}/media` with storage checks, private WebP handling, and ETag support.
- Add dedicated `PostResource`, OpenAPI docs updates, tests, and DB index for cursor pagination.

## Validation
- composer run ci:check
- npm run build
