### PR TITLE
Add expandable space description cards

### DIFF
--- a/resources/js/components/social/comment-thread.tsx
+++ b/resources/js/components/social/comment-thread.tsx
@@ -20,6 +20,8 @@ export type ReportReason = {
     label: string;
 };
 
+const COMMENT_PREVIEW_LENGTH = 180;
+
 type CommentThreadProps = {
     postId: number;
     postUrl: string;
@@ -132,6 +134,12 @@ export function CommentRow({
     reportReasons: ReportReason[];
 }) {
     const [reporting, setReporting] = useState(false);
+    const hasLongBody = comment.body.length > COMMENT_PREVIEW_LENGTH;
+    const [expanded, setExpanded] = useState(false);
+    const previewBody =
+        hasLongBody && !expanded
+            ? `${comment.body.slice(0, COMMENT_PREVIEW_LENGTH)}…`
+            : comment.body;
 
     return (
         <article
@@ -162,8 +170,18 @@ export function CommentRow({
                         </time>
                     </div>
                     <p className="mt-1 text-sm leading-6 whitespace-pre-wrap text-foreground/90">
-                        {comment.body}
+                        {previewBody}
                     </p>
+                    {hasLongBody && (
+                        <button
+                            type="button"
+                            className="social-focus mt-2 inline-flex min-h-7 items-center rounded-md px-2.5 py-0.5 text-[0.68rem] font-extrabold text-muted-foreground transition-colors hover:bg-secondary/70"
+                            onClick={() => setExpanded((open) => !open)}
+                            aria-expanded={expanded}
+                        >
+                            {expanded ? 'Show less' : 'Read more'}
+                        </button>
+                    )}
                 </div>
                 <div className="mt-1 flex min-h-7 items-center pl-2">
                     {comment.hasReported ? (

--- a/resources/js/pages/spaces/index.tsx
+++ b/resources/js/pages/spaces/index.tsx
@@ -60,11 +60,13 @@ function SpaceCard({
     const descriptionFallback =
         'A focused home for useful conversations and shared interests.';
     const description = space.description ?? descriptionFallback;
-    const hasLongDescription = description.length > SPACE_DESCRIPTION_PREVIEW_LENGTH;
+    const hasLongDescription =
+        description.length > SPACE_DESCRIPTION_PREVIEW_LENGTH;
     const [expanded, setExpanded] = useState(false);
-    const previewDescription = hasLongDescription && !expanded
-        ? `${description.slice(0, SPACE_DESCRIPTION_PREVIEW_LENGTH)}…`
-        : description;
+    const previewDescription =
+        hasLongDescription && !expanded
+            ? `${description.slice(0, SPACE_DESCRIPTION_PREVIEW_LENGTH)}…`
+            : description;
 
     return (
         <article className="social-card social-card-interactive group flex min-h-64 flex-col overflow-hidden rounded-[1.35rem]">

--- a/resources/js/pages/spaces/index.tsx
+++ b/resources/js/pages/spaces/index.tsx
@@ -46,6 +46,8 @@ const visibilityCopy = {
     },
 } as const;
 
+const SPACE_DESCRIPTION_PREVIEW_LENGTH = 160;
+
 function SpaceCard({
     space,
     onJoin,
@@ -55,6 +57,14 @@ function SpaceCard({
 }) {
     const visibility = visibilityCopy[space.visibility];
     const VisibilityIcon = visibility.icon;
+    const descriptionFallback =
+        'A focused home for useful conversations and shared interests.';
+    const description = space.description ?? descriptionFallback;
+    const hasLongDescription = description.length > SPACE_DESCRIPTION_PREVIEW_LENGTH;
+    const [expanded, setExpanded] = useState(false);
+    const previewDescription = hasLongDescription && !expanded
+        ? `${description.slice(0, SPACE_DESCRIPTION_PREVIEW_LENGTH)}…`
+        : description;
 
     return (
         <article className="social-card social-card-interactive group flex min-h-64 flex-col overflow-hidden rounded-[1.35rem]">
@@ -72,10 +82,19 @@ function SpaceCard({
                 <h3 className="text-lg font-black tracking-[-0.025em]">
                     {space.name}
                 </h3>
-                <p className="mt-1.5 line-clamp-2 text-sm leading-6 text-muted-foreground">
-                    {space.description ??
-                        'A focused home for useful conversations and shared interests.'}
+                <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+                    {previewDescription}
                 </p>
+                {hasLongDescription && (
+                    <button
+                        type="button"
+                        className="social-focus mt-2 inline-flex min-h-7 items-center rounded-md px-2.5 py-0.5 text-[0.68rem] font-extrabold text-muted-foreground transition-colors hover:bg-secondary/70"
+                        onClick={() => setExpanded((open) => !open)}
+                        aria-expanded={expanded}
+                    >
+                        {expanded ? 'Show less' : 'Read more'}
+                    </button>
+                )}
                 <div className="mt-auto flex items-center justify-between gap-3 pt-5">
                     <span className="flex items-center gap-1.5 text-xs font-bold text-muted-foreground">
                         <UsersRound className="size-3.5" aria-hidden="true" />


### PR DESCRIPTION
### What changed
- Add a compact/expandable Space card description preview on `/spaces` cards.
- Long descriptions now show a 160 character preview with `Read more` / `Show less`.

### Why
The Spaces directory is now easier to scan and stays readable while still allowing full community context on demand.

### Validation
- npm run lint:check
- npm run types:check
- npm run build
