### PR TITLE
Add private Saved Posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable project changes will be documented here.
 - Cursor-paginated post detail and comments APIs for native clients with
   policy-enforced access: `GET /api/v1/posts/{post}` and
   `GET /api/v1/posts/{post}/comments`.
+- Private Saved Posts with idempotent save/remove actions, current-visibility
+  filtering, and a dedicated responsive reading-list view.
+- Accessible feed-card actions for copying a permanent link and opening the
+  full conversation directly.
 
 ### Changed
 
@@ -50,6 +54,8 @@ All notable project changes will be documented here.
   horizontal scroll rail remains edge-to-edge.
 - README product previews now show the current desktop feed, mobile feed, and
   member-profile interfaces.
+- Long feed posts, comments, and Space-card descriptions now stay compact with
+  explicit read-more controls that preserve the complete content on demand.
 
 ## [0.1.0-alpha.1] - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
 - Expiring email invitations for restricted Spaces with hashed tokens and verified-account matching.
 - Owner transfer, moderator role changes, reason-required member removal, and an auditable management log.
 - A chronological, non-algorithmic feed.
+- Private Saved Posts with policy-filtered retrieval and quick access from the
+  desktop rail and mobile header.
 - Membership-protected comments with compact feed previews, permanent post
   links, and a full visibility-filtered paginated conversation view.
 - One optional image per post with required alternative text, private storage,

--- a/app/Community/CommunityFeed.php
+++ b/app/Community/CommunityFeed.php
@@ -53,9 +53,9 @@ final class CommunityFeed
     }
 
     /**
-     * @return list<array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, comments: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string}}>
+     * @return list<array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, isSaved: bool, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, comments: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string}}>
      */
-    public function posts(User $user, ?Space $space = null): array
+    public function posts(User $user, ?Space $space = null, bool $savedOnly = false): array
     {
         $hiddenActorIds = DB::table('user_relationships')
             ->select('target_id')
@@ -75,10 +75,10 @@ final class CommunityFeed
             ->whereNotIn('user_id', clone $blockingActorIds);
 
         $query = Post::query()
-            ->whereNotNull('published_at')
-            ->whereNull('hidden_at')
-            ->whereNotIn('user_id', clone $hiddenActorIds)
-            ->whereNotIn('user_id', clone $blockingActorIds)
+            ->whereNotNull('posts.published_at')
+            ->whereNull('posts.hidden_at')
+            ->whereNotIn('posts.user_id', clone $hiddenActorIds)
+            ->whereNotIn('posts.user_id', clone $blockingActorIds)
             ->with([
                 'author:id,name,handle',
                 'space:id,name,slug,visibility',
@@ -89,22 +89,42 @@ final class CommunityFeed
                     ->latest('id')
                     ->limit(6),
             ])
-            ->withCount(['comments as comments_count' => $visibleComments]);
+            ->withCount(['comments as comments_count' => $visibleComments])
+            ->withExists([
+                'saves as is_saved' => fn ($saves) => $saves
+                    ->where('user_id', $user->getKey()),
+            ]);
+
+        if ($savedOnly) {
+            $query
+                ->join('post_saves', function ($join) use ($user): void {
+                    $join
+                        ->on('post_saves.post_id', '=', 'posts.id')
+                        ->where('post_saves.user_id', $user->getKey());
+                })
+                ->addSelect('posts.*');
+        }
 
         if ($space instanceof Space) {
             $query->whereBelongsTo($space);
         } else {
             $query->whereIn(
-                'space_id',
+                'posts.space_id',
                 Space::query()->discoverableBy($user)->select('id'),
             );
         }
 
-        $posts = $query
-            ->latest('published_at')
-            ->latest('id')
-            ->limit(30)
-            ->get();
+        if ($savedOnly) {
+            $query
+                ->orderByDesc('post_saves.created_at')
+                ->orderByDesc('post_saves.id');
+        } else {
+            $query
+                ->latest('posts.published_at')
+                ->latest('posts.id');
+        }
+
+        $posts = $query->limit(30)->get();
 
         $comments = $posts->flatMap(fn (Post $post) => $post->comments);
         $visibleAuthorIds = User::query()
@@ -137,6 +157,7 @@ final class CommunityFeed
                 'body' => $post->body,
                 'media' => $this->media->for($post),
                 'publishedAt' => $post->published_at?->toIso8601String(),
+                'isSaved' => (bool) $post->is_saved,
                 'canComment' => in_array($post->space_id, $memberSpaceIds, true),
                 'canReport' => $post->user_id !== $user->getKey(),
                 'hasReported' => in_array($post->getKey(), $reportedPostIds, true),

--- a/app/Community/PostConversation.php
+++ b/app/Community/PostConversation.php
@@ -21,7 +21,7 @@ final class PostConversation
      * Build the policy-filtered permalink projection for one post.
      *
      * @return array{
-     *     post: array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, isDraft: bool, isHidden: bool, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string, description: string|null, visibility: string, memberCount: int}},
+     *     post: array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, isDraft: bool, isHidden: bool, isSaved: bool, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string, description: string|null, visibility: string, memberCount: int}},
      *     comments: array{data: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, meta: array{currentPage: int, lastPage: int, perPage: int, total: int}, links: array{newer: string|null, older: string|null}}
      * }
      */
@@ -33,6 +33,10 @@ final class PostConversation
             'media',
         ]);
         $post->space->loadCount('members');
+        $post->loadExists([
+            'saves as is_saved' => fn ($saves) => $saves
+                ->where('user_id', $viewer->getKey()),
+        ]);
 
         $comments = $this->visibleComments($viewer, $post)
             ->with('author:id,name,handle')
@@ -80,6 +84,7 @@ final class PostConversation
                 'publishedAt' => $post->published_at?->toIso8601String(),
                 'isDraft' => $post->published_at === null,
                 'isHidden' => $post->hidden_at !== null,
+                'isSaved' => (bool) $post->is_saved,
                 'canComment' => $viewer->can('comment', $post),
                 'canReport' => $viewer->can('report', $post),
                 'hasReported' => PostReport::query()

--- a/app/Http/Controllers/SavedPostController.php
+++ b/app/Http/Controllers/SavedPostController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Community\CommunityFeed;
+use App\Enums\ReportReason;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SavedPostController extends Controller
+{
+    public function index(Request $request, CommunityFeed $feed): Response
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        return Inertia::render('feed/index', [
+            'spaces' => $feed->spaces($user),
+            'posts' => $feed->posts($user, savedOnly: true),
+            'reportReasons' => ReportReason::options(),
+            'selectedSpace' => null,
+            'viewMode' => 'saved',
+        ]);
+    }
+
+    public function store(Request $request, Post $post): RedirectResponse
+    {
+        Gate::authorize('save', $post);
+
+        DB::table('post_saves')->insertOrIgnore([
+            'user_id' => $request->user()->getAuthIdentifier(),
+            'post_id' => $post->getKey(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return back()->with('status', 'Post saved for later.');
+    }
+
+    public function destroy(Request $request, Post $post): RedirectResponse
+    {
+        DB::table('post_saves')
+            ->where('user_id', $request->user()->getAuthIdentifier())
+            ->where('post_id', $post->getKey())
+            ->delete();
+
+        return back()->with('status', 'Post removed from saved.');
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Carbon;
  * @property-read Space $space
  * @property-read User $author
  * @property-read PostMedia|null $media
+ * @property-read int $is_saved
  */
 class Post extends Model
 {
@@ -83,6 +84,12 @@ class Post extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /** @return HasMany<PostSave, $this> */
+    public function saves(): HasMany
+    {
+        return $this->hasMany(PostSave::class);
     }
 
     /** @return HasOne<PostMedia, $this> */

--- a/app/Models/PostSave.php
+++ b/app/Models/PostSave.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PostSave extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'post_id',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<Post, $this> */
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -125,6 +125,12 @@ class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
         return $this->hasMany(Post::class);
     }
 
+    /** @return HasMany<PostSave, $this> */
+    public function postSaves(): HasMany
+    {
+        return $this->hasMany(PostSave::class);
+    }
+
     /** @return HasMany<Comment, $this> */
     public function comments(): HasMany
     {

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -40,6 +40,13 @@ class PostPolicy
             && $post->space->hasMember($user);
     }
 
+    public function save(User $user, Post $post): bool
+    {
+        return $post->published_at !== null
+            && $post->hidden_at === null
+            && $this->view($user, $post);
+    }
+
     public function delete(User $user, Post $post): bool
     {
         return $post->user_id === $user->getKey() || $user->can('moderate', $post->space);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -81,6 +81,9 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for('notification-actions', fn (Request $request): Limit => Limit::perMinute(60)
             ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
 
+        RateLimiter::for('post-saving', fn (Request $request): Limit => Limit::perMinute(60)
+            ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
+
         RateLimiter::for('api-read', function (Request $request): Limit {
             $token = $request->user()?->currentAccessToken();
             $tokenId = $token instanceof PersonalAccessToken ? $token->getKey() : 'none';

--- a/database/migrations/2026_07_22_000000_create_post_saves_table.php
+++ b/database/migrations/2026_07_22_000000_create_post_saves_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('post_saves', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'post_id']);
+            $table->index(['user_id', 'created_at', 'id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('post_saves');
+    }
+};

--- a/resources/js/components/social/social-nav.tsx
+++ b/resources/js/components/social/social-nav.tsx
@@ -1,6 +1,7 @@
 import { Link, usePage } from '@inertiajs/react';
 import {
     Bell,
+    Bookmark,
     Compass,
     Feather,
     Home,
@@ -33,6 +34,12 @@ const navItems = [
         subtitle: 'Discover members',
         href: '/people',
         icon: UsersRound,
+    },
+    {
+        title: 'Saved',
+        subtitle: 'Your private reading list',
+        href: '/saved',
+        icon: Bookmark,
     },
     {
         title: 'Notifications',
@@ -211,6 +218,13 @@ export function MobileSocialHeader() {
             </span>
             {auth.user ? (
                 <div className="flex items-center gap-1.5">
+                    <Link
+                        href="/saved"
+                        aria-label="Saved posts"
+                        className="social-focus flex size-10 items-center justify-center rounded-full text-foreground transition-colors hover:bg-secondary"
+                    >
+                        <Bookmark className="size-5" aria-hidden="true" />
+                    </Link>
                     <Link
                         href="/notifications"
                         aria-label={`Notifications${notificationSummary.unreadCount > 0 ? `, ${notificationSummary.unreadCount} unread` : ''}`}

--- a/resources/js/pages/feed/index.tsx
+++ b/resources/js/pages/feed/index.tsx
@@ -1,6 +1,7 @@
 import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
 import {
     ArrowRight,
+    Bookmark,
     ChevronDown,
     Flag,
     Globe2,
@@ -46,6 +47,7 @@ type FeedPost = {
     canComment: boolean;
     canReport: boolean;
     hasReported: boolean;
+    isSaved: boolean;
     commentsCount: number;
     comments: SocialComment[];
     author: { name: string; handle: string; profileVisible: boolean };
@@ -62,6 +64,7 @@ type FeedProps = {
     posts: FeedPost[];
     reportReasons: ReportReason[];
     selectedSpace: string | null;
+    viewMode?: 'feed' | 'saved';
     status?: string;
 };
 
@@ -357,6 +360,7 @@ function PostCard({
     const [reporting, setReporting] = useState(false);
     const [copyFeedback, setCopyFeedback] = useState(false);
     const [copyTimer, setCopyTimer] = useState<number | null>(null);
+    const [saving, setSaving] = useState(false);
     const [, copy] = useClipboard();
     const { data, setData, post, processing, errors, reset } = useForm({
         reason: '',
@@ -397,6 +401,23 @@ function PostCard({
         setCopyFeedback(true);
         const timer = window.setTimeout(() => setCopyFeedback(false), 2000);
         setCopyTimer(timer);
+    };
+
+    const toggleSaved = () => {
+        const url = `/posts/${item.id}/save`;
+        const options = {
+            preserveScroll: true,
+            onStart: () => setSaving(true),
+            onFinish: () => setSaving(false),
+        };
+
+        if (item.isSaved) {
+            router.delete(url, options);
+
+            return;
+        }
+
+        router.put(url, {}, options);
     };
 
     return (
@@ -440,6 +461,23 @@ function PostCard({
                     </Link>
                 </div>
                 <div className="flex shrink-0 flex-wrap items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={toggleSaved}
+                        disabled={saving}
+                        aria-pressed={item.isSaved}
+                        className={`social-focus inline-flex min-h-9 items-center gap-1.5 rounded-xl px-3 text-xs font-bold transition-colors disabled:opacity-60 ${
+                            item.isSaved
+                                ? 'bg-primary/10 text-primary hover:bg-primary/15'
+                                : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+                        }`}
+                    >
+                        <Bookmark
+                            className={`size-3.5 ${item.isSaved ? 'fill-current' : ''}`}
+                            aria-hidden="true"
+                        />
+                        {item.isSaved ? 'Saved' : 'Save'}
+                    </button>
                     <button
                         type="button"
                         onClick={handleCopy}
@@ -666,8 +704,10 @@ export default function Feed({
     posts,
     reportReasons,
     selectedSpace,
+    viewMode = 'feed',
     status,
 }: FeedProps) {
+    const savedView = viewMode === 'saved';
     const selected = spaces.find((space) => space.slug === selectedSpace);
     const postingSpaces = selected
         ? selected.isMember
@@ -686,7 +726,15 @@ export default function Feed({
 
     return (
         <>
-            <Head title={selected ? selected.name : 'Home'} />
+            <Head
+                title={
+                    savedView
+                        ? 'Saved posts'
+                        : selected
+                          ? selected.name
+                          : 'Home'
+                }
+            />
             <main className="social-page">
                 <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,44rem)_20rem] xl:justify-center">
                     <div className="min-w-0">
@@ -695,19 +743,26 @@ export default function Feed({
                                 <div>
                                     <div className="flex items-center gap-2 text-xs font-extrabold tracking-[0.12em] text-primary uppercase">
                                         <CommunitySignal />
-                                        {selected
-                                            ? 'Inside this space'
-                                            : 'Your social home'}
+                                        {savedView
+                                            ? 'Your private library'
+                                            : selected
+                                              ? 'Inside this space'
+                                              : 'Your social home'}
                                     </div>
                                     <h1 className="mt-1 text-2xl font-black tracking-[-0.035em] sm:text-[2rem]">
-                                        {selected?.name ?? 'Good to see you.'}
+                                        {savedView
+                                            ? 'Saved posts'
+                                            : (selected?.name ??
+                                              'Good to see you.')}
                                     </h1>
                                     <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
-                                        {selected?.description ??
-                                            'Fresh conversations from the communities you chose — always chronological.'}
+                                        {savedView
+                                            ? 'A private reading list of conversations you want to revisit.'
+                                            : (selected?.description ??
+                                              'Fresh conversations from the communities you chose — always chronological.')}
                                     </p>
                                 </div>
-                                {selected && (
+                                {selected && !savedView && (
                                     <div className="flex flex-wrap items-center gap-2">
                                         {selected.canManage && (
                                             <Button asChild variant="outline">
@@ -745,7 +800,7 @@ export default function Feed({
                             </div>
                         </header>
 
-                        {!selected && (
+                        {!selected && !savedView && (
                             <SpacePulse
                                 spaces={spaces.filter(
                                     (space) => space.isMember,
@@ -763,23 +818,35 @@ export default function Feed({
 
                         <section
                             className="space-y-3 sm:space-y-4"
-                            aria-label="Community feed"
+                            aria-label={
+                                savedView ? 'Saved posts' : 'Community feed'
+                            }
                         >
-                            <Composer spaces={postingSpaces} />
+                            {!savedView && <Composer spaces={postingSpaces} />}
                             {posts.length === 0 ? (
                                 <div className="social-card rounded-[1.35rem] px-6 py-12 text-center">
                                     <div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                                        <UsersRound
-                                            className="size-6"
-                                            aria-hidden="true"
-                                        />
+                                        {savedView ? (
+                                            <Bookmark
+                                                className="size-6"
+                                                aria-hidden="true"
+                                            />
+                                        ) : (
+                                            <UsersRound
+                                                className="size-6"
+                                                aria-hidden="true"
+                                            />
+                                        )}
                                     </div>
                                     <h2 className="mt-4 text-lg font-extrabold">
-                                        The room is ready.
+                                        {savedView
+                                            ? 'Nothing saved yet.'
+                                            : 'The room is ready.'}
                                     </h2>
                                     <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">
-                                        Be the first member to start a
-                                        thoughtful conversation here.
+                                        {savedView
+                                            ? 'Use Save on any post to keep it here for later.'
+                                            : 'Be the first member to start a thoughtful conversation here.'}
                                     </p>
                                 </div>
                             ) : (

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -1,6 +1,7 @@
-import { Head, Link, useForm } from '@inertiajs/react';
+import { Head, Link, router, useForm } from '@inertiajs/react';
 import {
     ArrowLeft,
+    Bookmark,
     ChevronLeft,
     ChevronRight,
     Flag,
@@ -36,6 +37,7 @@ type ConversationPost = {
     publishedAt: string | null;
     isDraft: boolean;
     isHidden: boolean;
+    isSaved: boolean;
     canComment: boolean;
     canReport: boolean;
     hasReported: boolean;
@@ -93,6 +95,7 @@ export default function ShowPost({
     const [reporting, setReporting] = useState(false);
     const [copyFeedback, setCopyFeedback] = useState(false);
     const [copyTimer, setCopyTimer] = useState<number | null>(null);
+    const [saving, setSaving] = useState(false);
     const [, copy] = useClipboard();
 
     useEffect(
@@ -146,6 +149,23 @@ export default function ShowPost({
         setCopyFeedback(true);
         const timer = window.setTimeout(() => setCopyFeedback(false), 2000);
         setCopyTimer(timer);
+    };
+
+    const toggleSaved = () => {
+        const url = `/posts/${post.id}/save`;
+        const options = {
+            preserveScroll: true,
+            onStart: () => setSaving(true),
+            onFinish: () => setSaving(false),
+        };
+
+        if (post.isSaved) {
+            router.delete(url, options);
+
+            return;
+        }
+
+        router.put(url, {}, options);
     };
 
     return (
@@ -241,6 +261,23 @@ export default function ShowPost({
                                         </div>
                                     </div>
                                     <div className="flex shrink-0 flex-wrap items-center gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={toggleSaved}
+                                            disabled={saving}
+                                            aria-pressed={post.isSaved}
+                                            className={`social-focus inline-flex min-h-9 items-center gap-1.5 rounded-xl px-3 text-xs font-bold transition-colors disabled:opacity-60 ${
+                                                post.isSaved
+                                                    ? 'bg-primary/10 text-primary hover:bg-primary/15'
+                                                    : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+                                            }`}
+                                        >
+                                            <Bookmark
+                                                className={`size-3.5 ${post.isSaved ? 'fill-current' : ''}`}
+                                                aria-hidden="true"
+                                            />
+                                            {post.isSaved ? 'Saved' : 'Save'}
+                                        </button>
                                         <button
                                             type="button"
                                             onClick={handleCopy}

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\PostController;
 use App\Http\Controllers\PostImageController;
 use App\Http\Controllers\PostReportController;
 use App\Http\Controllers\PostReportModerationController;
+use App\Http\Controllers\SavedPostController;
 use App\Http\Controllers\SpaceController;
 use App\Http\Controllers\SpaceInvitationAcceptanceController;
 use App\Http\Controllers\SpaceInvitationController;
@@ -24,6 +25,7 @@ Route::inertia('/', 'welcome')->name('home');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('feed', FeedController::class)->name('feed');
+    Route::get('saved', [SavedPostController::class, 'index'])->name('saved.index');
     Route::get('notifications', [NotificationController::class, 'index'])
         ->name('notifications.index');
     Route::post('notifications/{notification}/open', [NotificationController::class, 'open'])
@@ -106,6 +108,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('posts/{post}/reports', [PostReportController::class, 'store'])
         ->middleware('throttle:post-reporting')
         ->name('posts.reports.store');
+    Route::put('posts/{post}/save', [SavedPostController::class, 'store'])
+        ->middleware('throttle:post-saving')
+        ->name('posts.saves.store');
+    Route::delete('posts/{post}/save', [SavedPostController::class, 'destroy'])
+        ->middleware('throttle:post-saving')
+        ->name('posts.saves.destroy');
     Route::post('posts/{post}/comments', [CommentController::class, 'store'])
         ->middleware('throttle:comment-publishing')
         ->name('posts.comments.store');

--- a/tests/Feature/SavedPostTest.php
+++ b/tests/Feature/SavedPostTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class SavedPostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saved_posts_require_a_verified_member(): void
+    {
+        $post = Post::factory()->create();
+
+        $this->get(route('saved.index'))->assertRedirect(route('login'));
+
+        $this->actingAs(User::factory()->unverified()->create())
+            ->put(route('posts.saves.store', $post))
+            ->assertRedirect(route('verification.notice'));
+
+        $this->assertDatabaseEmpty('post_saves');
+    }
+
+    public function test_a_visible_post_can_be_saved_idempotently_and_exposed_to_its_viewer(): void
+    {
+        $viewer = User::factory()->create();
+        $post = Post::factory()->create();
+
+        $this->actingAs($viewer)
+            ->from(route('feed'))
+            ->put(route('posts.saves.store', $post))
+            ->assertRedirect(route('feed'))
+            ->assertSessionHas('status', 'Post saved for later.');
+
+        $this->actingAs($viewer)
+            ->put(route('posts.saves.store', $post))
+            ->assertRedirect();
+
+        $this->assertDatabaseCount('post_saves', 1);
+        $this->assertDatabaseHas('post_saves', [
+            'user_id' => $viewer->getKey(),
+            'post_id' => $post->getKey(),
+        ]);
+
+        $this->actingAs($viewer)
+            ->get(route('feed'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('posts.0.id', $post->getKey())
+                ->where('posts.0.isSaved', true));
+    }
+
+    public function test_draft_hidden_and_inaccessible_private_posts_cannot_be_saved(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create();
+        $publicSpace = Space::factory()->create();
+        $privateSpace = Space::factory()->private()->create();
+        $draft = Post::factory()->for($publicSpace)->for($author, 'author')->create([
+            'published_at' => null,
+        ]);
+        $hidden = Post::factory()->for($publicSpace)->for($author, 'author')->create([
+            'hidden_at' => now(),
+        ]);
+        $private = Post::factory()->for($privateSpace)->for($author, 'author')->create();
+
+        foreach ([$draft, $hidden, $private] as $post) {
+            $this->actingAs($viewer)
+                ->put(route('posts.saves.store', $post))
+                ->assertForbidden();
+        }
+
+        $this->assertDatabaseEmpty('post_saves');
+    }
+
+    public function test_removing_a_save_only_changes_the_current_members_library(): void
+    {
+        $viewer = User::factory()->create();
+        $other = User::factory()->create();
+        $post = Post::factory()->create();
+
+        DB::table('post_saves')->insert([
+            [
+                'user_id' => $viewer->getKey(),
+                'post_id' => $post->getKey(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'user_id' => $other->getKey(),
+                'post_id' => $post->getKey(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $this->actingAs($viewer)
+            ->from(route('saved.index'))
+            ->delete(route('posts.saves.destroy', $post))
+            ->assertRedirect(route('saved.index'))
+            ->assertSessionHas('status', 'Post removed from saved.');
+
+        $this->assertDatabaseMissing('post_saves', [
+            'user_id' => $viewer->getKey(),
+            'post_id' => $post->getKey(),
+        ]);
+        $this->assertDatabaseHas('post_saves', [
+            'user_id' => $other->getKey(),
+            'post_id' => $post->getKey(),
+        ]);
+    }
+
+    public function test_saved_posts_are_private_ordered_and_reapply_current_visibility(): void
+    {
+        $viewer = User::factory()->create();
+        $other = User::factory()->create();
+        $space = Space::factory()->create();
+        $older = Post::factory()->for($space)->create(['body' => 'Saved first']);
+        $newer = Post::factory()->for($space)->create(['body' => 'Saved second']);
+        $hidden = Post::factory()->for($space)->create([
+            'body' => 'No longer visible',
+            'hidden_at' => now(),
+        ]);
+        $otherPost = Post::factory()->for($space)->create(['body' => 'Someone else saved this']);
+
+        DB::table('post_saves')->insert([
+            [
+                'user_id' => $viewer->getKey(),
+                'post_id' => $older->getKey(),
+                'created_at' => now()->subMinute(),
+                'updated_at' => now()->subMinute(),
+            ],
+            [
+                'user_id' => $viewer->getKey(),
+                'post_id' => $newer->getKey(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'user_id' => $viewer->getKey(),
+                'post_id' => $hidden->getKey(),
+                'created_at' => now()->addMinute(),
+                'updated_at' => now()->addMinute(),
+            ],
+            [
+                'user_id' => $other->getKey(),
+                'post_id' => $otherPost->getKey(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $this->actingAs($viewer)
+            ->get(route('saved.index'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('feed/index')
+                ->where('viewMode', 'saved')
+                ->has('posts', 2)
+                ->where('posts.0.body', 'Saved second')
+                ->where('posts.0.isSaved', true)
+                ->where('posts.1.body', 'Saved first')
+                ->where('posts.1.isSaved', true));
+    }
+
+    public function test_post_permalink_exposes_only_the_current_members_save_state(): void
+    {
+        $viewer = User::factory()->create();
+        $post = Post::factory()->create();
+
+        DB::table('post_saves')->insert([
+            'user_id' => $viewer->getKey(),
+            'post_id' => $post->getKey(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('post.id', $post->getKey())
+                ->where('post.isSaved', true));
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('posts.show', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('post.isSaved', false));
+    }
+}


### PR DESCRIPTION
## Why

Members need a private way to keep useful conversations without changing the chronological feed or exposing public engagement metrics.

## What changed

- adds idempotent save and remove actions with policy and rate-limit boundaries
- adds a visibility-filtered Saved Posts view ordered by save time
- exposes private save state on feed cards and post permalinks
- adds desktop and mobile navigation plus responsive empty states
- documents the feature and covers authentication, isolation, ordering, and visibility regressions

## Validation

- composer run ci:check — 155 tests, 1,578 assertions; PHPStan, Pint, ESLint, Prettier, and TypeScript passed
- npm run build
- composer validate --strict
- composer audit --no-interaction — no advisories
- npm audit --omit=dev --audit-level=high — 0 vulnerabilities

Browser screenshots remain a manual follow-up because the available browser session blocks local 127.0.0.1 URLs.