### PR TITLE
Add author controls for posts and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ All notable project changes will be documented here.
 - Policy-filtered global search across visible posts, accessible Spaces, and
   discoverable people, with grouped responsive results, bounded queries, and
   dedicated desktop/mobile navigation.
+- Author-controlled post and comment editing and deletion with explicit edited
+  timestamps, responsive management dialogs, strict ownership checks, and
+  active moderation-review locks.
 
 ### Changed
 
@@ -59,6 +62,8 @@ All notable project changes will be documented here.
   member-profile interfaces.
 - Long feed posts, comments, and Space-card descriptions now stay compact with
   explicit read-more controls that preserve the complete content on demand.
+- Read-only post and comment API resources now include a nullable `edited_at`
+  timestamp so clients can distinguish publication from later author changes.
 
 ## [0.1.0-alpha.1] - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
   desktop rail and mobile header.
 - Membership-protected comments with compact feed previews, permanent post
   links, and a full visibility-filtered paginated conversation view.
+- Author-controlled editing and deletion for posts and comments, with visible
+  edited state and content changes locked while an active moderation review is
+  in progress.
 - One optional image per post with required alternative text, private storage,
   policy-protected delivery, and metadata-stripping WebP normalization.
 - Private post and comment reporting with allowlisted reasons, duplicate protection, and separate rate limits.

--- a/app/Community/CommunityFeed.php
+++ b/app/Community/CommunityFeed.php
@@ -2,6 +2,7 @@
 
 namespace App\Community;
 
+use App\Enums\ReportStatus;
 use App\Enums\SpaceRole;
 use App\Enums\UserRelationshipType;
 use App\Models\Comment;
@@ -53,7 +54,7 @@ final class CommunityFeed
     }
 
     /**
-     * @return list<array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, isSaved: bool, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, comments: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string}}>
+     * @return list<array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, editedAt: string|null, isSaved: bool, canComment: bool, canReport: bool, canEdit: bool, canDelete: bool, hasReported: bool, commentsCount: int, comments: list<array{id: int, body: string, publishedAt: string, editedAt: string|null, canReport: bool, canEdit: bool, canDelete: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string}}>
      */
     public function posts(User $user, ?Space $space = null, bool $savedOnly = false): array
     {
@@ -145,6 +146,21 @@ final class CommunityFeed
             ->pluck('comment_id')
             ->all();
 
+        $activeStatuses = [
+            ReportStatus::Open->value,
+            ReportStatus::Reviewing->value,
+        ];
+        $lockedPostIds = PostReport::query()
+            ->whereIn('post_id', $posts->modelKeys())
+            ->whereIn('status', $activeStatuses)
+            ->pluck('post_id')
+            ->all();
+        $lockedCommentIds = CommentReport::query()
+            ->whereIn('comment_id', $comments->pluck('id')->all())
+            ->whereIn('status', $activeStatuses)
+            ->pluck('comment_id')
+            ->all();
+
         $memberSpaceIds = DB::table('space_members')
             ->where('user_id', $user->getKey())
             ->pluck('space_id')
@@ -157,9 +173,14 @@ final class CommunityFeed
                 'body' => $post->body,
                 'media' => $this->media->for($post),
                 'publishedAt' => $post->published_at?->toIso8601String(),
+                'editedAt' => $post->edited_at?->toIso8601String(),
                 'isSaved' => (bool) $post->is_saved,
                 'canComment' => in_array($post->space_id, $memberSpaceIds, true),
                 'canReport' => $post->user_id !== $user->getKey(),
+                'canEdit' => $post->user_id === $user->getKey()
+                    && ! in_array($post->getKey(), $lockedPostIds, true),
+                'canDelete' => $post->user_id === $user->getKey()
+                    && ! in_array($post->getKey(), $lockedPostIds, true),
                 'hasReported' => in_array($post->getKey(), $reportedPostIds, true),
                 'commentsCount' => (int) $post->comments_count,
                 'comments' => array_values($post->comments
@@ -168,7 +189,12 @@ final class CommunityFeed
                         'id' => $comment->getKey(),
                         'body' => $comment->body,
                         'publishedAt' => $comment->published_at->toIso8601String(),
+                        'editedAt' => $comment->edited_at?->toIso8601String(),
                         'canReport' => $comment->user_id !== $user->getKey(),
+                        'canEdit' => $comment->user_id === $user->getKey()
+                            && ! in_array($comment->getKey(), $lockedCommentIds, true),
+                        'canDelete' => $comment->user_id === $user->getKey()
+                            && ! in_array($comment->getKey(), $lockedCommentIds, true),
                         'hasReported' => in_array($comment->getKey(), $reportedCommentIds, true),
                         'author' => [
                             'name' => $comment->author->name,

--- a/app/Community/ManageAuthoredContent.php
+++ b/app/Community/ManageAuthoredContent.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Community;
+
+use App\Enums\ReportStatus;
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+
+final class ManageAuthoredContent
+{
+    public function updatePost(User $author, Post $post, string $body): bool
+    {
+        return DB::transaction(function () use ($author, $post, $body): bool {
+            $lockedPost = Post::query()
+                ->whereKey($post->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            Gate::forUser($author)->authorize('update', $lockedPost);
+            $this->ensurePostIsNotUnderReview($lockedPost);
+
+            if ($lockedPost->body === $body) {
+                return false;
+            }
+
+            return $lockedPost->update([
+                'body' => $body,
+                'edited_at' => now(),
+            ]);
+        });
+    }
+
+    public function deletePost(User $author, Post $post): void
+    {
+        DB::transaction(function () use ($author, $post): void {
+            $lockedPost = Post::query()
+                ->whereKey($post->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            Gate::forUser($author)->authorize('delete', $lockedPost);
+            $this->ensurePostIsNotUnderReview($lockedPost);
+            $lockedPost->delete();
+        });
+    }
+
+    public function updateComment(User $author, Comment $comment, string $body): bool
+    {
+        return DB::transaction(function () use ($author, $comment, $body): bool {
+            $lockedComment = Comment::query()
+                ->with('post')
+                ->whereKey($comment->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            Gate::forUser($author)->authorize('update', $lockedComment);
+            $this->ensureCommentIsNotUnderReview($lockedComment);
+
+            if ($lockedComment->body === $body) {
+                return false;
+            }
+
+            return $lockedComment->update([
+                'body' => $body,
+                'edited_at' => now(),
+            ]);
+        });
+    }
+
+    public function deleteComment(User $author, Comment $comment): void
+    {
+        DB::transaction(function () use ($author, $comment): void {
+            $lockedComment = Comment::query()
+                ->with('post')
+                ->whereKey($comment->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            Gate::forUser($author)->authorize('delete', $lockedComment);
+            $this->ensureCommentIsNotUnderReview($lockedComment);
+            $lockedComment->delete();
+        });
+    }
+
+    private function ensurePostIsNotUnderReview(Post $post): void
+    {
+        if ($post->reports()->whereIn('status', $this->activeStatuses())->exists()) {
+            $this->throwUnderReview();
+        }
+    }
+
+    private function ensureCommentIsNotUnderReview(Comment $comment): void
+    {
+        if ($comment->reports()->whereIn('status', $this->activeStatuses())->exists()) {
+            $this->throwUnderReview();
+        }
+    }
+
+    /** @return list<string> */
+    private function activeStatuses(): array
+    {
+        return [
+            ReportStatus::Open->value,
+            ReportStatus::Reviewing->value,
+        ];
+    }
+
+    private function throwUnderReview(): never
+    {
+        throw ValidationException::withMessages([
+            'content' => 'This content cannot be changed while a moderation review is active.',
+        ]);
+    }
+}

--- a/app/Community/PostConversation.php
+++ b/app/Community/PostConversation.php
@@ -2,6 +2,7 @@
 
 namespace App\Community;
 
+use App\Enums\ReportStatus;
 use App\Enums\UserRelationshipType;
 use App\Models\Comment;
 use App\Models\CommentReport;
@@ -21,8 +22,8 @@ final class PostConversation
      * Build the policy-filtered permalink projection for one post.
      *
      * @return array{
-     *     post: array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, isDraft: bool, isHidden: bool, isSaved: bool, canComment: bool, canReport: bool, hasReported: bool, commentsCount: int, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string, description: string|null, visibility: string, memberCount: int}},
-     *     comments: array{data: list<array{id: int, body: string, publishedAt: string, canReport: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, meta: array{currentPage: int, lastPage: int, perPage: int, total: int}, links: array{newer: string|null, older: string|null}}
+     *     post: array{id: int, url: string, body: string, media: array{url: string, alt: string, width: int, height: int}|null, publishedAt: string|null, editedAt: string|null, isDraft: bool, isHidden: bool, isSaved: bool, canComment: bool, canReport: bool, canEdit: bool, canDelete: bool, hasReported: bool, commentsCount: int, author: array{name: string, handle: string, profileVisible: bool}, space: array{name: string, slug: string, description: string|null, visibility: string, memberCount: int}},
+     *     comments: array{data: list<array{id: int, body: string, publishedAt: string, editedAt: string|null, canReport: bool, canEdit: bool, canDelete: bool, hasReported: bool, author: array{name: string, handle: string, profileVisible: bool}}>, meta: array{currentPage: int, lastPage: int, perPage: int, total: int}, links: array{newer: string|null, older: string|null}}
      * }
      */
     public function for(User $viewer, Post $post): array
@@ -56,6 +57,19 @@ final class PostConversation
             ->whereIn('comment_id', $commentModels->pluck('id')->all())
             ->pluck('comment_id')
             ->all();
+        $activeStatuses = [
+            ReportStatus::Open->value,
+            ReportStatus::Reviewing->value,
+        ];
+        $postIsLocked = PostReport::query()
+            ->where('post_id', $post->getKey())
+            ->whereIn('status', $activeStatuses)
+            ->exists();
+        $lockedCommentIds = CommentReport::query()
+            ->whereIn('comment_id', $commentModels->pluck('id')->all())
+            ->whereIn('status', $activeStatuses)
+            ->pluck('comment_id')
+            ->all();
 
         $commentData = [];
 
@@ -65,7 +79,12 @@ final class PostConversation
                 'id' => $comment->id,
                 'body' => $comment->body,
                 'publishedAt' => $comment->published_at->toIso8601String(),
+                'editedAt' => $comment->edited_at?->toIso8601String(),
                 'canReport' => $viewer->can('report', $comment),
+                'canEdit' => $viewer->can('update', $comment)
+                    && ! in_array($comment->getKey(), $lockedCommentIds, true),
+                'canDelete' => $viewer->can('delete', $comment)
+                    && ! in_array($comment->getKey(), $lockedCommentIds, true),
                 'hasReported' => in_array($comment->id, $reportedCommentIds, true),
                 'author' => [
                     'name' => $comment->author->name,
@@ -82,11 +101,14 @@ final class PostConversation
                 'body' => $post->body,
                 'media' => $this->media->for($post),
                 'publishedAt' => $post->published_at?->toIso8601String(),
+                'editedAt' => $post->edited_at?->toIso8601String(),
                 'isDraft' => $post->published_at === null,
                 'isHidden' => $post->hidden_at !== null,
                 'isSaved' => (bool) $post->is_saved,
                 'canComment' => $viewer->can('comment', $post),
                 'canReport' => $viewer->can('report', $post),
+                'canEdit' => $viewer->can('update', $post) && ! $postIsLocked,
+                'canDelete' => $viewer->can('delete', $post) && ! $postIsLocked,
                 'hasReported' => PostReport::query()
                     ->where('post_id', $post->getKey())
                     ->where('reporter_id', $viewer->getKey())

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -2,10 +2,16 @@
 
 namespace App\Http\Controllers;
 
+use App\Community\ManageAuthoredContent;
 use App\Events\CommentPublished;
 use App\Http\Requests\StoreCommentRequest;
+use App\Http\Requests\UpdateCommentRequest;
+use App\Models\Comment;
 use App\Models\Post;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class CommentController extends Controller
 {
@@ -20,5 +26,34 @@ class CommentController extends Controller
         CommentPublished::dispatch($comment);
 
         return back()->with('status', 'Comment published.');
+    }
+
+    public function update(
+        UpdateCommentRequest $request,
+        Comment $comment,
+        ManageAuthoredContent $content,
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $request->user();
+        $changed = $content->updateComment(
+            $user,
+            $comment,
+            $request->string('body')->toString(),
+        );
+
+        return back()->with('status', $changed ? 'Comment updated.' : 'No changes to save.');
+    }
+
+    public function destroy(
+        Request $request,
+        Comment $comment,
+        ManageAuthoredContent $content,
+    ): RedirectResponse {
+        Gate::authorize('delete', $comment);
+        /** @var User $user */
+        $user = $request->user();
+        $content->deleteComment($user, $comment);
+
+        return back()->with('status', 'Comment deleted.');
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Community\ManageAuthoredContent;
 use App\Community\PostConversation;
 use App\Community\PublishPost;
 use App\Enums\ReportReason;
 use App\Http\Requests\StorePostRequest;
+use App\Http\Requests\UpdatePostRequest;
 use App\Models\Post;
 use App\Models\Space;
 use App\Models\User;
@@ -51,5 +53,34 @@ class PostController extends Controller
         );
 
         return back()->with('status', 'Post published.');
+    }
+
+    public function update(
+        UpdatePostRequest $request,
+        Post $post,
+        ManageAuthoredContent $content,
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $request->user();
+        $changed = $content->updatePost(
+            $user,
+            $post,
+            $request->string('body')->toString(),
+        );
+
+        return back()->with('status', $changed ? 'Post updated.' : 'No changes to save.');
+    }
+
+    public function destroy(
+        Request $request,
+        Post $post,
+        ManageAuthoredContent $content,
+    ): RedirectResponse {
+        Gate::authorize('delete', $post);
+        /** @var User $user */
+        $user = $request->user();
+        $content->deletePost($user, $post);
+
+        return redirect()->route('feed')->with('status', 'Post deleted.');
     }
 }

--- a/app/Http/Requests/UpdateCommentRequest.php
+++ b/app/Http/Requests/UpdateCommentRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Comment;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $comment = $this->route('comment');
+
+        return $comment instanceof Comment
+            && $this->user()?->can('update', $comment) === true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:1000'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge(['body' => trim((string) $this->input('body'))]);
+    }
+}

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Post;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $post = $this->route('post');
+
+        return $post instanceof Post
+            && $this->user()?->can('update', $post) === true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:2000'],
+        ];
+    }
+
+    /** @return array<string, string> */
+    public function messages(): array
+    {
+        return [
+            'body.required' => 'Write something before saving.',
+            'body.max' => 'Posts can be up to 2,000 characters.',
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge(['body' => trim((string) $this->input('body'))]);
+    }
+}

--- a/app/Http/Resources/Api/V1/CommentResource.php
+++ b/app/Http/Resources/Api/V1/CommentResource.php
@@ -19,6 +19,7 @@ class CommentResource extends JsonResource
             'id' => (string) $comment->getKey(),
             'body' => $comment->body,
             'published_at' => $comment->published_at->toIso8601String(),
+            'edited_at' => $comment->edited_at?->toIso8601String(),
             'author' => [
                 'handle' => $comment->author->handle,
                 'name' => $comment->author->name,

--- a/app/Http/Resources/Api/V1/PostResource.php
+++ b/app/Http/Resources/Api/V1/PostResource.php
@@ -21,6 +21,7 @@ class PostResource extends JsonResource
             'id' => (string) $post->getKey(),
             'body' => $post->body,
             'published_at' => $post->published_at?->toIso8601String(),
+            'edited_at' => $post->edited_at?->toIso8601String(),
             'media' => $media instanceof PostMedia ? [
                 'url' => route('api.v1.posts.media', $post),
                 'alt' => $media->alt_text,

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Carbon;
  * @property int $user_id
  * @property string $body
  * @property Carbon $published_at
+ * @property Carbon|null $edited_at
  * @property Carbon|null $hidden_at
  * @property int|null $hidden_by
  * @property string|null $moderation_note
@@ -31,6 +32,7 @@ class Comment extends Model
         'user_id',
         'body',
         'published_at',
+        'edited_at',
         'hidden_at',
         'hidden_by',
         'moderation_note',
@@ -41,6 +43,7 @@ class Comment extends Model
     {
         return [
             'published_at' => 'immutable_datetime',
+            'edited_at' => 'immutable_datetime',
             'hidden_at' => 'immutable_datetime',
         ];
     }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Carbon;
  * @property int $user_id
  * @property string $body
  * @property Carbon|null $published_at
+ * @property Carbon|null $edited_at
  * @property Carbon|null $hidden_at
  * @property int|null $hidden_by
  * @property string|null $moderation_note
@@ -42,6 +43,7 @@ class Post extends Model
         'user_id',
         'body',
         'published_at',
+        'edited_at',
         'hidden_at',
         'hidden_by',
         'moderation_note',
@@ -52,6 +54,7 @@ class Post extends Model
     {
         return [
             'published_at' => 'immutable_datetime',
+            'edited_at' => 'immutable_datetime',
             'hidden_at' => 'immutable_datetime',
         ];
     }

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -27,9 +27,15 @@ class CommentPolicy
             && $this->view($user, $comment);
     }
 
-    public function delete(User $user, Comment $comment): bool
+    public function update(User $user, Comment $comment): bool
     {
         return $comment->user_id === $user->getKey()
-            || $user->can('moderate', $comment->post->space);
+            && $comment->hidden_at === null
+            && $comment->post->hidden_at === null;
+    }
+
+    public function delete(User $user, Comment $comment): bool
+    {
+        return $this->update($user, $comment);
     }
 }

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -47,8 +47,15 @@ class PostPolicy
             && $this->view($user, $post);
     }
 
+    public function update(User $user, Post $post): bool
+    {
+        return $post->user_id === $user->getKey()
+            && $post->published_at !== null
+            && $post->hidden_at === null;
+    }
+
     public function delete(User $user, Post $post): bool
     {
-        return $post->user_id === $user->getKey() || $user->can('moderate', $post->space);
+        return $this->update($user, $post);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -63,6 +63,9 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for('comment-reporting', fn (Request $request): Limit => Limit::perHour(10)
             ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
 
+        RateLimiter::for('content-management', fn (Request $request): Limit => Limit::perMinute(30)
+            ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
+
         RateLimiter::for('space-creation', fn (Request $request): Limit => Limit::perHour(5)
             ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
 

--- a/database/migrations/2026_07_23_000002_add_edited_at_to_posts_and_comments.php
+++ b/database/migrations/2026_07_23_000002_add_edited_at_to_posts_and_comments.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->timestamp('edited_at')->nullable()->after('published_at');
+        });
+
+        Schema::table('comments', function (Blueprint $table): void {
+            $table->timestamp('edited_at')->nullable()->after('published_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table): void {
+            $table->dropColumn('edited_at');
+        });
+
+        Schema::table('posts', function (Blueprint $table): void {
+            $table->dropColumn('edited_at');
+        });
+    }
+};

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -191,7 +191,8 @@ The first resources expose only allowlisted fields:
   metadata, relationship rows, and undiscoverable membership;
 - Spaces exclude invitation recipients, audit records, and hidden membership;
 - posts and comments exclude storage paths, report details, moderator notes,
-  hidden timestamps, and author account identifiers;
+  hidden timestamps, and author account identifiers; nullable `edited_at`
+  communicates an author change without exposing internal update timestamps;
 - media exposes only the authorized API URL, alt text, normalized dimensions,
   and MIME type;
 - notifications are re-resolved at read time and expose a safe structured

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -11,6 +11,9 @@ This contract is pre-release and may receive additive changes before the first t
 3. Space owners and moderators can move an open report into review, hide the content, or dismiss the report.
 4. Hiding removes the content from community surfaces. Reopening restores it only when no other resolved report still requires it to remain hidden.
 5. Review, hide, dismiss, and reopen actions append a `SpaceAuditLog` entry with report and content identifiers. Reporter identity is not copied into the general audit log.
+6. Authors may edit or delete their own visible content, except while any report
+   is open or under review. This prevents content or evidence from changing
+   during an active moderation decision.
 
 Current states are `open`, `reviewing`, `resolved`, and `dismissed`. Current moderator actions are `review`, `hide`, `dismiss`, and `reopen`.
 
@@ -38,14 +41,17 @@ Listeners should be idempotent and queued when they perform I/O. Treat report de
 
 ## Authorization and integrity boundaries
 
-- `PostPolicy` controls post visibility, commenting, reporting, and deletion.
-- `CommentPolicy` controls comment visibility, reporting, and deletion.
+- `PostPolicy` controls post visibility, commenting, reporting, author editing,
+  and deletion.
+- `CommentPolicy` controls comment visibility, reporting, author editing, and
+  deletion.
 - `SpacePolicy::moderate` controls queue access and decisions.
 - Form Requests and transaction-backed domain services both enforce authorization.
 - Moderator routes use scoped nested binding; services repeat Space/report/content relationship checks under row locks.
 - Reason and action values are backed by shared enums; clients cannot invent workflow states.
 - Report `space_id` values are derived from content on the server and are never accepted from client input.
-- Post and comment publishing/reporting use separate per-user rate limiters.
+- Post and comment publishing/reporting use separate per-user rate limiters;
+  author edit/delete mutations share a dedicated per-user limiter.
 
 Frontend visibility is only a convenience. Extensions must never treat a hidden button or a client-provided Space identifier as authorization.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1078,6 +1078,7 @@
           "id",
           "body",
           "published_at",
+          "edited_at",
           "author",
           "viewer"
         ],
@@ -1091,6 +1092,13 @@
           },
           "published_at": {
             "type": "string",
+            "format": "date-time"
+          },
+          "edited_at": {
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "author": {
@@ -1121,6 +1129,7 @@
           "id",
           "body",
           "published_at",
+          "edited_at",
           "media",
           "comments_count",
           "author",
@@ -1137,6 +1146,13 @@
           },
           "published_at": {
             "type": "string",
+            "format": "date-time"
+          },
+          "edited_at": {
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time"
           },
           "media": {

--- a/resources/js/components/social/authored-content-menu.tsx
+++ b/resources/js/components/social/authored-content-menu.tsx
@@ -1,0 +1,239 @@
+import { router, useForm } from '@inertiajs/react';
+import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+type AuthoredContentMenuProps = {
+    body: string;
+    canEdit: boolean;
+    canDelete: boolean;
+    contentType: 'post' | 'comment';
+    updateUrl: string;
+    deleteUrl: string;
+    maxLength: number;
+    compact?: boolean;
+};
+
+export function AuthoredContentMenu({
+    body,
+    canEdit,
+    canDelete,
+    contentType,
+    updateUrl,
+    deleteUrl,
+    maxLength,
+    compact = false,
+}: AuthoredContentMenuProps) {
+    const [editing, setEditing] = useState(false);
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+    const { data, setData, patch, processing, errors, clearErrors } = useForm<{
+        body: string;
+        content?: string;
+    }>({ body });
+    const noun = contentType === 'post' ? 'post' : 'comment';
+
+    if (!canEdit && !canDelete) {
+        return null;
+    }
+
+    const openEditor = () => {
+        setData('body', body);
+        clearErrors();
+        setEditing(true);
+    };
+
+    const submitEdit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        patch(updateUrl, {
+            preserveScroll: true,
+            onSuccess: () => setEditing(false),
+        });
+    };
+
+    const destroy = () => {
+        setDeleteError(null);
+        router.delete(deleteUrl, {
+            preserveScroll: true,
+            onSuccess: () => setConfirmingDelete(false),
+            onError: (responseErrors) => {
+                setDeleteError(
+                    typeof responseErrors.content === 'string'
+                        ? responseErrors.content
+                        : `The ${noun} could not be deleted.`,
+                );
+            },
+        });
+    };
+
+    return (
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <button
+                        type="button"
+                        aria-label={`Manage your ${noun}`}
+                        className={`social-focus inline-flex shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground ${
+                            compact ? '-my-1.5 size-11' : 'size-11'
+                        }`}
+                    >
+                        <MoreHorizontal
+                            className={compact ? 'size-4' : 'size-[1.1rem]'}
+                            aria-hidden="true"
+                        />
+                    </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                    align="end"
+                    className="w-44 rounded-xl p-1.5"
+                >
+                    {canEdit && (
+                        <DropdownMenuItem
+                            onSelect={openEditor}
+                            className="min-h-11 rounded-lg font-semibold"
+                        >
+                            <Pencil aria-hidden="true" />
+                            Edit {noun}
+                        </DropdownMenuItem>
+                    )}
+                    {canDelete && (
+                        <DropdownMenuItem
+                            variant="destructive"
+                            onSelect={() => {
+                                setDeleteError(null);
+                                setConfirmingDelete(true);
+                            }}
+                            className="min-h-11 rounded-lg font-semibold"
+                        >
+                            <Trash2 aria-hidden="true" />
+                            Delete {noun}
+                        </DropdownMenuItem>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            <Dialog open={editing} onOpenChange={setEditing}>
+                <DialogContent className="rounded-[1.35rem] border-border/80 p-5 sm:max-w-xl sm:p-6">
+                    <DialogHeader>
+                        <DialogTitle className="text-xl font-black tracking-tight">
+                            Edit {noun}
+                        </DialogTitle>
+                        <DialogDescription className="leading-6">
+                            Keep the conversation clear. An edited label will be
+                            shown after you save.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <form onSubmit={submitEdit} className="space-y-4">
+                        <label className="block">
+                            <span className="sr-only">Updated {noun}</span>
+                            <textarea
+                                autoFocus
+                                value={data.body}
+                                onChange={(event) =>
+                                    setData('body', event.target.value)
+                                }
+                                maxLength={maxLength}
+                                rows={contentType === 'post' ? 7 : 4}
+                                required
+                                className="social-inset social-focus w-full resize-y px-4 py-3 text-[0.95rem] leading-7"
+                            />
+                        </label>
+                        <div className="flex items-center justify-between gap-3">
+                            <div>
+                                <InputError
+                                    message={errors.body ?? errors.content}
+                                />
+                                {!errors.body && !errors.content && (
+                                    <span className="text-xs font-semibold text-muted-foreground">
+                                        {data.body.length.toLocaleString()} /{' '}
+                                        {maxLength.toLocaleString()}
+                                    </span>
+                                )}
+                            </div>
+                            <DialogFooter className="flex-row">
+                                <DialogClose asChild>
+                                    <Button
+                                        type="button"
+                                        variant="secondary"
+                                        className="h-11"
+                                    >
+                                        Cancel
+                                    </Button>
+                                </DialogClose>
+                                <Button
+                                    type="submit"
+                                    className="h-11"
+                                    disabled={
+                                        processing ||
+                                        data.body.trim() === '' ||
+                                        data.body.trim() === body
+                                    }
+                                >
+                                    Save changes
+                                </Button>
+                            </DialogFooter>
+                        </div>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={confirmingDelete} onOpenChange={setConfirmingDelete}>
+                <DialogContent className="rounded-[1.35rem] border-border/80 p-5 sm:max-w-md sm:p-6">
+                    <DialogHeader>
+                        <DialogTitle className="text-xl font-black tracking-tight">
+                            Delete this {noun}?
+                        </DialogTitle>
+                        <DialogDescription className="leading-6">
+                            This permanently removes it
+                            {contentType === 'post'
+                                ? ' together with its comments'
+                                : ''}{' '}
+                            and cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    {deleteError && (
+                        <p className="rounded-xl bg-destructive/10 px-3 py-2 text-sm font-semibold text-destructive">
+                            {deleteError}
+                        </p>
+                    )}
+                    <DialogFooter className="flex-row">
+                        <DialogClose asChild>
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                className="h-11"
+                            >
+                                Keep {noun}
+                            </Button>
+                        </DialogClose>
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={destroy}
+                            className="h-11"
+                        >
+                            Delete {noun}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/resources/js/components/social/comment-thread.tsx
+++ b/resources/js/components/social/comment-thread.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Flag, MessageCircle, Send } from 'lucide-react';
 import { useState } from 'react';
 import type { FormEvent } from 'react';
 import InputError from '@/components/input-error';
+import { AuthoredContentMenu } from '@/components/social/authored-content-menu';
 import { AvatarMark } from '@/components/social/avatar-mark';
 import { Button } from '@/components/ui/button';
 
@@ -10,7 +11,10 @@ export type SocialComment = {
     id: number;
     body: string;
     publishedAt: string;
+    editedAt: string | null;
     canReport: boolean;
+    canEdit: boolean;
+    canDelete: boolean;
     hasReported: boolean;
     author: { name: string; handle: string; profileVisible: boolean };
 };
@@ -149,25 +153,42 @@ export function CommentRow({
             <AvatarMark name={comment.author.name} className="mt-0.5 size-8" />
             <div className="min-w-0 flex-1">
                 <div className="rounded-2xl rounded-tl-md bg-secondary/58 px-3.5 py-2.5">
-                    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                        {comment.author.profileVisible ? (
-                            <Link
-                                href={`/people/${comment.author.handle}`}
-                                className="text-sm font-extrabold hover:underline"
+                    <div className="flex items-start justify-between gap-2">
+                        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                            {comment.author.profileVisible ? (
+                                <Link
+                                    href={`/people/${comment.author.handle}`}
+                                    className="truncate text-sm font-extrabold hover:underline"
+                                >
+                                    {comment.author.name}
+                                </Link>
+                            ) : (
+                                <span className="truncate text-sm font-extrabold">
+                                    {comment.author.name}
+                                </span>
+                            )}
+                            <time
+                                dateTime={comment.publishedAt}
+                                className="text-[0.68rem] font-semibold text-muted-foreground"
                             >
-                                {comment.author.name}
-                            </Link>
-                        ) : (
-                            <span className="text-sm font-extrabold">
-                                {comment.author.name}
-                            </span>
-                        )}
-                        <time
-                            dateTime={comment.publishedAt}
-                            className="text-[0.68rem] font-semibold text-muted-foreground"
-                        >
-                            {commentDateLabel(comment.publishedAt)}
-                        </time>
+                                {commentDateLabel(comment.publishedAt)}
+                            </time>
+                            {comment.editedAt && (
+                                <span className="text-[0.68rem] font-semibold text-muted-foreground">
+                                    Edited
+                                </span>
+                            )}
+                        </div>
+                        <AuthoredContentMenu
+                            body={comment.body}
+                            canEdit={comment.canEdit}
+                            canDelete={comment.canDelete}
+                            contentType="comment"
+                            updateUrl={`/comments/${comment.id}`}
+                            deleteUrl={`/comments/${comment.id}`}
+                            maxLength={1000}
+                            compact
+                        />
                     </div>
                     <p className="mt-1 text-sm leading-6 whitespace-pre-wrap text-foreground/90">
                         {previewBody}

--- a/resources/js/pages/feed/index.tsx
+++ b/resources/js/pages/feed/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import InputError from '@/components/input-error';
+import { AuthoredContentMenu } from '@/components/social/authored-content-menu';
 import { AvatarMark } from '@/components/social/avatar-mark';
 import { CommentThread } from '@/components/social/comment-thread';
 import type { SocialComment } from '@/components/social/comment-thread';
@@ -44,8 +45,11 @@ type FeedPost = {
     body: string;
     media: PostMedia | null;
     publishedAt: string | null;
+    editedAt: string | null;
     canComment: boolean;
     canReport: boolean;
+    canEdit: boolean;
+    canDelete: boolean;
     hasReported: boolean;
     isSaved: boolean;
     commentsCount: number;
@@ -458,9 +462,23 @@ function PostCard({
                         <time dateTime={item.publishedAt ?? undefined}>
                             {publishedLabel(item.publishedAt)}
                         </time>
+                        {item.editedAt && (
+                            <span className="ml-1.5" aria-label="Edited post">
+                                · Edited
+                            </span>
+                        )}
                     </Link>
                 </div>
                 <div className="flex shrink-0 flex-wrap items-center gap-2">
+                    <AuthoredContentMenu
+                        body={item.body}
+                        canEdit={item.canEdit}
+                        canDelete={item.canDelete}
+                        contentType="post"
+                        updateUrl={`/posts/${item.id}`}
+                        deleteUrl={`/posts/${item.id}`}
+                        maxLength={2000}
+                    />
                     <button
                         type="button"
                         onClick={toggleSaved}

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -13,6 +13,7 @@ import {
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import InputError from '@/components/input-error';
+import { AuthoredContentMenu } from '@/components/social/authored-content-menu';
 import { AvatarMark } from '@/components/social/avatar-mark';
 import {
     CommentComposer,
@@ -35,11 +36,14 @@ type ConversationPost = {
     body: string;
     media: PostMedia | null;
     publishedAt: string | null;
+    editedAt: string | null;
     isDraft: boolean;
     isHidden: boolean;
     isSaved: boolean;
     canComment: boolean;
     canReport: boolean;
+    canEdit: boolean;
+    canDelete: boolean;
     hasReported: boolean;
     commentsCount: number;
     author: { name: string; handle: string; profileVisible: boolean };
@@ -251,6 +255,14 @@ export default function ShowPost({
                                                     post.publishedAt,
                                                 )}
                                             </time>
+                                            {post.editedAt && (
+                                                <>
+                                                    <span aria-hidden="true">
+                                                        ·
+                                                    </span>
+                                                    <span>Edited</span>
+                                                </>
+                                            )}
                                             <span aria-hidden="true">·</span>
                                             <Link
                                                 href={spaceUrl}
@@ -261,6 +273,15 @@ export default function ShowPost({
                                         </div>
                                     </div>
                                     <div className="flex shrink-0 flex-wrap items-center gap-2">
+                                        <AuthoredContentMenu
+                                            body={post.body}
+                                            canEdit={post.canEdit}
+                                            canDelete={post.canDelete}
+                                            contentType="post"
+                                            updateUrl={`/posts/${post.id}`}
+                                            deleteUrl={`/posts/${post.id}`}
+                                            maxLength={2000}
+                                        />
                                         <button
                                             type="button"
                                             onClick={toggleSaved}

--- a/routes/web.php
+++ b/routes/web.php
@@ -107,6 +107,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('spaces.posts.store');
     Route::get('posts/{post}', [PostController::class, 'show'])
         ->name('posts.show');
+    Route::patch('posts/{post}', [PostController::class, 'update'])
+        ->middleware('throttle:content-management')
+        ->name('posts.update');
+    Route::delete('posts/{post}', [PostController::class, 'destroy'])
+        ->middleware('throttle:content-management')
+        ->name('posts.destroy');
     Route::get('posts/{post}/image', PostImageController::class)
         ->name('posts.image');
     Route::post('posts/{post}/reports', [PostReportController::class, 'store'])
@@ -121,6 +127,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('posts/{post}/comments', [CommentController::class, 'store'])
         ->middleware('throttle:comment-publishing')
         ->name('posts.comments.store');
+    Route::patch('comments/{comment}', [CommentController::class, 'update'])
+        ->middleware('throttle:content-management')
+        ->name('comments.update');
+    Route::delete('comments/{comment}', [CommentController::class, 'destroy'])
+        ->middleware('throttle:content-management')
+        ->name('comments.destroy');
     Route::post('comments/{comment}/reports', [CommentReportController::class, 'store'])
         ->middleware('throttle:comment-reporting')
         ->name('comments.reports.store');

--- a/tests/Feature/Api/FeedTest.php
+++ b/tests/Feature/Api/FeedTest.php
@@ -119,7 +119,7 @@ class FeedTest extends TestCase
             ->assertHeader('X-RateLimit-Limit', '120');
 
         $this->assertSame(
-            ['id', 'body', 'published_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
             array_keys($response->json('data.0')),
         );
         $this->assertSame(

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -91,7 +91,7 @@ class PostApiTest extends TestCase
             ->assertJsonMissingPath('data.media.author_id');
 
         $this->assertSame(
-            ['id', 'body', 'published_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
             array_keys($response->json('data')),
         );
         $this->assertSame(

--- a/tests/Feature/AuthoredContentManagementTest.php
+++ b/tests/Feature/AuthoredContentManagementTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\ReportStatus;
+use App\Models\Comment;
+use App\Models\CommentReport;
+use App\Models\Post;
+use App\Models\PostReport;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class AuthoredContentManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_author_can_edit_a_post_and_the_ui_receives_an_explicit_edited_state(): void
+    {
+        $author = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($author);
+        $post = Post::factory()->for($space)->for($author, 'author')->create([
+            'body' => 'Original post',
+        ]);
+
+        $this->actingAs($author)
+            ->patch(route('posts.update', $post), ['body' => '  Improved post copy.  '])
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Post updated.');
+
+        $post->refresh();
+
+        $this->assertSame('Improved post copy.', $post->body);
+        $this->assertNotNull($post->edited_at);
+
+        $this->actingAs($author)
+            ->get(route('feed'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('posts.0.body', 'Improved post copy.')
+                ->where('posts.0.canEdit', true)
+                ->where('posts.0.canDelete', true)
+                ->where('posts.0.editedAt', $post->edited_at?->toIso8601String()));
+    }
+
+    public function test_author_can_edit_a_comment_and_the_conversation_receives_author_controls(): void
+    {
+        $author = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($author);
+        $post = Post::factory()->for($space)->create();
+        $comment = Comment::factory()->for($post)->for($author, 'author')->create([
+            'body' => 'Original reply',
+        ]);
+
+        $this->actingAs($author)
+            ->patch(route('comments.update', $comment), ['body' => '  Clearer reply.  '])
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Comment updated.');
+
+        $comment->refresh();
+
+        $this->assertSame('Clearer reply.', $comment->body);
+        $this->assertNotNull($comment->edited_at);
+
+        $this->actingAs($author)
+            ->get(route('posts.show', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('comments.data.0.body', 'Clearer reply.')
+                ->where('comments.data.0.canEdit', true)
+                ->where('comments.data.0.canDelete', true)
+                ->where('comments.data.0.editedAt', $comment->edited_at?->toIso8601String()));
+    }
+
+    public function test_members_cannot_change_or_delete_content_authored_by_someone_else(): void
+    {
+        $author = User::factory()->create();
+        $otherMember = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($author);
+        $space->addMember($otherMember);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+        $comment = Comment::factory()->for($post)->for($author, 'author')->create();
+
+        $this->actingAs($otherMember)
+            ->patch(route('posts.update', $post), ['body' => 'Unauthorized edit'])
+            ->assertForbidden();
+        $this->actingAs($otherMember)
+            ->delete(route('posts.destroy', $post))
+            ->assertForbidden();
+        $this->actingAs($otherMember)
+            ->patch(route('comments.update', $comment), ['body' => 'Unauthorized edit'])
+            ->assertForbidden();
+        $this->actingAs($otherMember)
+            ->delete(route('comments.destroy', $comment))
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('posts', ['id' => $post->getKey()]);
+        $this->assertDatabaseHas('comments', ['id' => $comment->getKey()]);
+    }
+
+    public function test_active_moderation_reports_lock_author_edits_and_deletions(): void
+    {
+        $author = User::factory()->create();
+        $reporter = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($author);
+        $space->addMember($reporter);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+        $comment = Comment::factory()->for($post)->for($author, 'author')->create();
+
+        PostReport::factory()
+            ->for($space)
+            ->for($post)
+            ->for($reporter, 'reporter')
+            ->create(['status' => ReportStatus::Reviewing]);
+        CommentReport::factory()
+            ->for($space)
+            ->for($comment)
+            ->for($reporter, 'reporter')
+            ->create(['status' => ReportStatus::Open]);
+
+        $this->actingAs($author)
+            ->patch(route('posts.update', $post), ['body' => 'Changed while under review'])
+            ->assertSessionHasErrors('content');
+        $this->actingAs($author)
+            ->delete(route('posts.destroy', $post))
+            ->assertSessionHasErrors('content');
+        $this->actingAs($author)
+            ->patch(route('comments.update', $comment), ['body' => 'Changed while under review'])
+            ->assertSessionHasErrors('content');
+        $this->actingAs($author)
+            ->delete(route('comments.destroy', $comment))
+            ->assertSessionHasErrors('content');
+
+        $this->actingAs($author)
+            ->get(route('feed'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('posts.0.canEdit', false)
+                ->where('posts.0.canDelete', false)
+                ->where('posts.0.comments.0.canEdit', false)
+                ->where('posts.0.comments.0.canDelete', false));
+    }
+
+    public function test_author_can_delete_unreported_content_and_dismissed_reports_do_not_keep_it_locked(): void
+    {
+        $author = User::factory()->create();
+        $reporter = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($author);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+        $firstComment = Comment::factory()->for($post)->for($author, 'author')->create();
+        $secondComment = Comment::factory()->for($post)->for($author, 'author')->create();
+
+        CommentReport::factory()
+            ->for($space)
+            ->for($firstComment)
+            ->for($reporter, 'reporter')
+            ->create(['status' => ReportStatus::Dismissed]);
+
+        $this->actingAs($author)
+            ->delete(route('comments.destroy', $firstComment))
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Comment deleted.');
+
+        $this->assertDatabaseMissing('comments', ['id' => $firstComment->getKey()]);
+        $this->assertDatabaseHas('comments', ['id' => $secondComment->getKey()]);
+
+        $this->actingAs($author)
+            ->delete(route('posts.destroy', $post))
+            ->assertRedirect(route('feed'))
+            ->assertSessionHas('status', 'Post deleted.');
+
+        $this->assertDatabaseMissing('posts', ['id' => $post->getKey()]);
+        $this->assertDatabaseMissing('comments', ['id' => $secondComment->getKey()]);
+    }
+}

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -143,8 +143,12 @@ class ApiContractDocumentationTest extends TestCase
             array_keys($schemas['Space']['properties']),
         );
         $this->assertSame(
-            ['id', 'body', 'published_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
             array_keys($schemas['Post']['properties']),
+        );
+        $this->assertSame(
+            ['id', 'body', 'published_at', 'edited_at', 'author', 'viewer'],
+            array_keys($schemas['Comment']['properties']),
         );
         $this->assertSame(
             ['handle', 'name', 'headline', 'profile_visible'],


### PR DESCRIPTION
People need a safe way to correct or remove their own contributions without weakening the moderation record.

This adds author-only edit and delete controls for posts and comments, explicit edited timestamps, rate-limited mutations, and responsive management dialogs. Active moderation reports lock both actions; the domain service rechecks authorization inside a transaction and shares row locks with report creation so content cannot change mid-review.

The read-only API receives the additive nullable `edited_at` field, with OpenAPI and contract tests updated.

Validation:
- `composer run ci:check` — 165 tests, 1,735 assertions
- `npm run build`
- `composer validate --strict`
- Composer and production npm audits: no advisories
- Desktop and 390px browser QA for post/comment edit, cancel, delete confirmation, edited labels, and no horizontal overflow or console errors