### PR TITLE
Add typed post reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
   discoverable people, with dedicated desktop and mobile entry points.
 - Private Saved Posts with policy-filtered retrieval and quick access from the
   desktop rail and mobile header.
+- Typed Like, Celebrate, and Insightful post reactions with one viewer choice,
+  aggregate-only counts, and a responsive feed/permalink interaction.
 - Membership-protected comments with compact feed previews, permanent post
   links, and a full visibility-filtered paginated conversation view.
 - Author-controlled editing and deletion for posts and comments, with visible

--- a/app/Community/CommunityFeed.php
+++ b/app/Community/CommunityFeed.php
@@ -16,7 +16,10 @@ use Illuminate\Support\Facades\DB;
 
 final class CommunityFeed
 {
-    public function __construct(private readonly PostMediaView $media) {}
+    public function __construct(
+        private readonly PostMediaView $media,
+        private readonly PostReactionProjection $reactions,
+    ) {}
 
     /**
      * @return list<array{name: string, slug: string, description: string|null, visibility: 'public'|'private'|'hidden', memberCount: int, isMember: bool, isOwner: bool, canManage: bool}>
@@ -126,6 +129,7 @@ final class CommunityFeed
         }
 
         $posts = $query->limit(30)->get();
+        $reactionProjection = $this->reactions->forPosts($posts, $user);
 
         $comments = $posts->flatMap(fn (Post $post) => $post->comments);
         $visibleAuthorIds = User::query()
@@ -175,6 +179,7 @@ final class CommunityFeed
                 'publishedAt' => $post->published_at?->toIso8601String(),
                 'editedAt' => $post->edited_at?->toIso8601String(),
                 'isSaved' => (bool) $post->is_saved,
+                'reactions' => $reactionProjection[$post->getKey()],
                 'canComment' => in_array($post->space_id, $memberSpaceIds, true),
                 'canReport' => $post->user_id !== $user->getKey(),
                 'canEdit' => $post->user_id === $user->getKey()

--- a/app/Community/PostConversation.php
+++ b/app/Community/PostConversation.php
@@ -10,13 +10,17 @@ use App\Models\Post;
 use App\Models\PostReport;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 
 final class PostConversation
 {
     private const COMMENTS_PER_PAGE = 20;
 
-    public function __construct(private readonly PostMediaView $media) {}
+    public function __construct(
+        private readonly PostMediaView $media,
+        private readonly PostReactionProjection $reactions,
+    ) {}
 
     /**
      * Build the policy-filtered permalink projection for one post.
@@ -38,6 +42,10 @@ final class PostConversation
             'saves as is_saved' => fn ($saves) => $saves
                 ->where('user_id', $viewer->getKey()),
         ]);
+        $reactionProjection = $this->reactions->forPosts(
+            new Collection([$post]),
+            $viewer,
+        );
 
         $comments = $this->visibleComments($viewer, $post)
             ->with('author:id,name,handle')
@@ -105,6 +113,7 @@ final class PostConversation
                 'isDraft' => $post->published_at === null,
                 'isHidden' => $post->hidden_at !== null,
                 'isSaved' => (bool) $post->is_saved,
+                'reactions' => $reactionProjection[$post->getKey()],
                 'canComment' => $viewer->can('comment', $post),
                 'canReport' => $viewer->can('report', $post),
                 'canEdit' => $viewer->can('update', $post) && ! $postIsLocked,

--- a/app/Community/PostReactionProjection.php
+++ b/app/Community/PostReactionProjection.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Community;
+
+use App\Enums\PostReactionType;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class PostReactionProjection
+{
+    /**
+     * Posts must already be filtered or authorized for the viewer.
+     *
+     * @param  Collection<int, Post>  $posts
+     * @return array<int, array{total: int, counts: array{like: int, celebrate: int, insightful: int}, viewerType: string|null, canReact: bool}>
+     */
+    public function forPosts(Collection $posts, User $viewer): array
+    {
+        $postIds = $posts->modelKeys();
+        $counts = [];
+
+        foreach ($postIds as $postId) {
+            $counts[$postId] = $this->emptyCounts();
+        }
+
+        if ($postIds !== []) {
+            DB::table('post_reactions')
+                ->select('post_id', 'type', DB::raw('COUNT(*) as aggregate'))
+                ->whereIn('post_id', $postIds)
+                ->groupBy('post_id', 'type')
+                ->get()
+                ->each(function (object $row) use (&$counts): void {
+                    $postId = (int) $row->post_id;
+                    $type = PostReactionType::tryFrom((string) $row->type);
+
+                    if ($type instanceof PostReactionType && isset($counts[$postId])) {
+                        $counts[$postId][$type->value] = (int) $row->aggregate;
+                    }
+                });
+        }
+
+        $viewerTypes = DB::table('post_reactions')
+            ->where('user_id', $viewer->getKey())
+            ->whereIn('post_id', $postIds)
+            ->pluck('type', 'post_id');
+        $projection = [];
+
+        foreach ($posts as $post) {
+            $postCounts = $counts[$post->getKey()] ?? $this->emptyCounts();
+            $viewerType = $viewerTypes->get($post->getKey());
+
+            $projection[$post->getKey()] = [
+                'total' => array_sum($postCounts),
+                'counts' => $postCounts,
+                'viewerType' => is_string($viewerType) ? $viewerType : null,
+                'canReact' => $post->published_at !== null
+                    && $post->hidden_at === null,
+            ];
+        }
+
+        return $projection;
+    }
+
+    /** @return array{like: int, celebrate: int, insightful: int} */
+    private function emptyCounts(): array
+    {
+        return [
+            PostReactionType::Like->value => 0,
+            PostReactionType::Celebrate->value => 0,
+            PostReactionType::Insightful->value => 0,
+        ];
+    }
+}

--- a/app/Community/ReactToPost.php
+++ b/app/Community/ReactToPost.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Community;
+
+use App\Enums\PostReactionType;
+use App\Events\PostReactionChanged;
+use App\Models\Post;
+use App\Models\PostReaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+
+final class ReactToPost
+{
+    /**
+     * @return array{changed: bool, previousType: PostReactionType|null}
+     */
+    public function set(User $user, Post $post, PostReactionType $type): array
+    {
+        $result = DB::transaction(function () use ($user, $post, $type): array {
+            $lockedPost = Post::query()
+                ->with(['author', 'space'])
+                ->whereKey($post->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+            Gate::forUser($user)->authorize('react', $lockedPost);
+
+            $reaction = PostReaction::query()
+                ->whereBelongsTo($lockedPost)
+                ->whereBelongsTo($user)
+                ->lockForUpdate()
+                ->first();
+            $previousType = $reaction?->type;
+
+            if ($previousType === $type) {
+                return [
+                    'changed' => false,
+                    'previousType' => $previousType,
+                    'post' => $lockedPost,
+                ];
+            }
+
+            PostReaction::query()->updateOrCreate(
+                [
+                    'post_id' => $lockedPost->getKey(),
+                    'user_id' => $user->getKey(),
+                ],
+                ['type' => $type],
+            );
+
+            return [
+                'changed' => true,
+                'previousType' => $previousType,
+                'post' => $lockedPost,
+            ];
+        });
+
+        if ($result['changed']) {
+            PostReactionChanged::dispatch(
+                $result['post'],
+                $user,
+                $result['previousType'],
+                $type,
+            );
+        }
+
+        return [
+            'changed' => $result['changed'],
+            'previousType' => $result['previousType'],
+        ];
+    }
+
+    public function remove(User $user, int|string $postId): bool
+    {
+        $reaction = DB::transaction(function () use ($user, $postId): ?PostReaction {
+            $candidate = PostReaction::query()
+                ->where('post_id', $postId)
+                ->whereBelongsTo($user)
+                ->first();
+
+            if (! $candidate instanceof PostReaction) {
+                return null;
+            }
+
+            $lockedPost = Post::query()
+                ->whereKey($candidate->post_id)
+                ->lockForUpdate()
+                ->firstOrFail();
+            $lockedReaction = PostReaction::query()
+                ->whereBelongsTo($lockedPost)
+                ->whereBelongsTo($user)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $lockedReaction instanceof PostReaction) {
+                return null;
+            }
+
+            $lockedReaction->setRelation('post', $lockedPost);
+            $lockedReaction->delete();
+
+            return $lockedReaction;
+        });
+
+        if (! $reaction instanceof PostReaction) {
+            return false;
+        }
+
+        PostReactionChanged::dispatch(
+            $reaction->post,
+            $user,
+            $reaction->type,
+            null,
+        );
+
+        return true;
+    }
+}

--- a/app/Enums/PostReactionType.php
+++ b/app/Enums/PostReactionType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+enum PostReactionType: string
+{
+    case Like = 'like';
+    case Celebrate = 'celebrate';
+    case Insightful = 'insightful';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Like => 'Like',
+            self::Celebrate => 'Celebrate',
+            self::Insightful => 'Insightful',
+        };
+    }
+
+    /** @return list<array{value: string, label: string}> */
+    public static function options(): array
+    {
+        return array_map(
+            fn (self $type): array => [
+                'value' => $type->value,
+                'label' => $type->label(),
+            ],
+            self::cases(),
+        );
+    }
+}

--- a/app/Events/PostReactionChanged.php
+++ b/app/Events/PostReactionChanged.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Events;
+
+use App\Enums\PostReactionType;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PostReactionChanged
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public readonly Post $post,
+        public readonly User $user,
+        public readonly ?PostReactionType $previousType,
+        public readonly ?PostReactionType $type,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/FeedController.php
+++ b/app/Http/Controllers/Api/V1/FeedController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Api\V1\FeedCursor;
+use App\Community\PostReactionProjection;
 use App\Community\VisiblePostQuery;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\PostResource;
@@ -22,6 +23,7 @@ class FeedController extends Controller
         Request $request,
         VisiblePostQuery $visiblePosts,
         FeedCursor $cursors,
+        PostReactionProjection $reactions,
     ): JsonResponse {
         /** @var User $viewer */
         $viewer = $request->user();
@@ -63,7 +65,7 @@ class FeedController extends Controller
         $hasMore = $posts->count() > $limit;
         $posts = $posts->take($limit)->values();
 
-        $this->addViewerState($posts, $viewer);
+        $this->addViewerState($posts, $viewer, $reactions);
 
         $lastPost = $posts->last();
         $nextCursor = $hasMore && $lastPost instanceof Post
@@ -93,8 +95,11 @@ class FeedController extends Controller
     }
 
     /** @param Collection<int, Post> $posts */
-    private function addViewerState(Collection $posts, User $viewer): void
-    {
+    private function addViewerState(
+        Collection $posts,
+        User $viewer,
+        PostReactionProjection $reactions,
+    ): void {
         $postIds = $posts->modelKeys();
         $authorIds = $posts->pluck('user_id')->unique()->values();
         $spaceIds = $posts->pluck('space_id')->unique()->values();
@@ -113,12 +118,14 @@ class FeedController extends Controller
             ->whereIn('space_id', $spaceIds)
             ->pluck('space_id')
             ->all();
+        $reactionProjection = $reactions->forPosts($posts, $viewer);
 
         $posts->each(function (Post $post) use (
             $viewer,
             $visibleAuthorIds,
             $reportedPostIds,
             $memberSpaceIds,
+            $reactionProjection,
         ): void {
             $post->setAttribute(
                 'author_profile_visible',
@@ -132,6 +139,18 @@ class FeedController extends Controller
             $post->setAttribute(
                 'viewer_has_reported',
                 in_array($post->getKey(), $reportedPostIds, true),
+            );
+            $post->setAttribute(
+                'reaction_counts',
+                $reactionProjection[$post->getKey()]['counts'],
+            );
+            $post->setAttribute(
+                'viewer_reaction_type',
+                $reactionProjection[$post->getKey()]['viewerType'],
+            );
+            $post->setAttribute(
+                'viewer_can_react',
+                $reactionProjection[$post->getKey()]['canReact'],
             );
         });
     }

--- a/app/Http/Controllers/Api/V1/PostController.php
+++ b/app/Http/Controllers/Api/V1/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Community\PostReactionProjection;
 use App\Community\VisiblePostQuery;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Api\V1\PostResource;
@@ -19,6 +20,7 @@ class PostController extends Controller
         Request $request,
         string $post,
         VisiblePostQuery $visiblePosts,
+        PostReactionProjection $reactions,
     ): JsonResponse {
         /** @var User $viewer */
         $viewer = $request->user();
@@ -27,7 +29,7 @@ class PostController extends Controller
             ->whereKey($post)
             ->firstOrFail();
 
-        $this->addViewerState(new Collection([$postModel]), $viewer);
+        $this->addViewerState(new Collection([$postModel]), $viewer, $reactions);
 
         return response()->json([
             'data' => (new PostResource($postModel))->toArray($request),
@@ -35,8 +37,11 @@ class PostController extends Controller
     }
 
     /** @param Collection<int, Post> $posts */
-    private function addViewerState(Collection $posts, User $viewer): void
-    {
+    private function addViewerState(
+        Collection $posts,
+        User $viewer,
+        PostReactionProjection $reactions,
+    ): void {
         $postIds = $posts->modelKeys();
         $authorIds = $posts->pluck('user_id')->unique()->values();
         $spaceIds = $posts->pluck('space_id')->unique()->values();
@@ -55,12 +60,14 @@ class PostController extends Controller
             ->whereIn('space_id', $spaceIds)
             ->pluck('space_id')
             ->all();
+        $reactionProjection = $reactions->forPosts($posts, $viewer);
 
         $posts->each(function (Post $post) use (
             $viewer,
             $visibleAuthorIds,
             $reportedPostIds,
             $memberSpaceIds,
+            $reactionProjection,
         ): void {
             $post->setAttribute(
                 'author_profile_visible',
@@ -74,6 +81,18 @@ class PostController extends Controller
             $post->setAttribute(
                 'viewer_has_reported',
                 in_array($post->getKey(), $reportedPostIds, true),
+            );
+            $post->setAttribute(
+                'reaction_counts',
+                $reactionProjection[$post->getKey()]['counts'],
+            );
+            $post->setAttribute(
+                'viewer_reaction_type',
+                $reactionProjection[$post->getKey()]['viewerType'],
+            );
+            $post->setAttribute(
+                'viewer_can_react',
+                $reactionProjection[$post->getKey()]['canReact'],
             );
         });
     }

--- a/app/Http/Controllers/FeedController.php
+++ b/app/Http/Controllers/FeedController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Community\CommunityFeed;
+use App\Enums\PostReactionType;
 use App\Enums\ReportReason;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -20,6 +21,7 @@ class FeedController extends Controller
             'spaces' => $feed->spaces($user),
             'posts' => $feed->posts($user),
             'reportReasons' => ReportReason::options(),
+            'reactionTypes' => PostReactionType::options(),
             'selectedSpace' => null,
         ]);
     }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Community\ManageAuthoredContent;
 use App\Community\PostConversation;
 use App\Community\PublishPost;
+use App\Enums\PostReactionType;
 use App\Enums\ReportReason;
 use App\Http\Requests\StorePostRequest;
 use App\Http\Requests\UpdatePostRequest;
@@ -30,6 +31,7 @@ class PostController extends Controller
         return Inertia::render('posts/show', [
             ...$conversation->for($user, $post),
             'reportReasons' => ReportReason::options(),
+            'reactionTypes' => PostReactionType::options(),
         ]);
     }
 

--- a/app/Http/Controllers/PostReactionController.php
+++ b/app/Http/Controllers/PostReactionController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Community\ReactToPost;
+use App\Enums\PostReactionType;
+use App\Http\Requests\StorePostReactionRequest;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class PostReactionController extends Controller
+{
+    public function store(
+        StorePostReactionRequest $request,
+        Post $post,
+        ReactToPost $reactions,
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $request->user();
+        $result = $reactions->set(
+            $user,
+            $post,
+            PostReactionType::from($request->string('type')->toString()),
+        );
+        $status = ! $result['changed']
+            ? 'Reaction unchanged.'
+            : ($result['previousType'] instanceof PostReactionType
+                ? 'Reaction updated.'
+                : 'Reaction added.');
+
+        return back()->with('status', $status);
+    }
+
+    public function destroy(
+        Request $request,
+        string $post,
+        ReactToPost $reactions,
+    ): RedirectResponse {
+        /** @var User $user */
+        $user = $request->user();
+        $removed = $reactions->remove($user, $post);
+
+        return back()->with(
+            'status',
+            $removed ? 'Reaction removed.' : 'No reaction to remove.',
+        );
+    }
+}

--- a/app/Http/Controllers/SavedPostController.php
+++ b/app/Http/Controllers/SavedPostController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Community\CommunityFeed;
+use App\Enums\PostReactionType;
 use App\Enums\ReportReason;
 use App\Models\Post;
 use App\Models\User;
@@ -24,6 +25,7 @@ class SavedPostController extends Controller
             'spaces' => $feed->spaces($user),
             'posts' => $feed->posts($user, savedOnly: true),
             'reportReasons' => ReportReason::options(),
+            'reactionTypes' => PostReactionType::options(),
             'selectedSpace' => null,
             'viewMode' => 'saved',
         ]);

--- a/app/Http/Controllers/SpaceController.php
+++ b/app/Http/Controllers/SpaceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Community\CommunityFeed;
 use App\Community\CreateSpace;
+use App\Enums\PostReactionType;
 use App\Enums\ReportReason;
 use App\Enums\SpaceVisibility;
 use App\Http\Requests\StoreSpaceRequest;
@@ -55,6 +56,7 @@ class SpaceController extends Controller
             'spaces' => $feed->spaces($user),
             'posts' => $feed->posts($user, $space),
             'reportReasons' => ReportReason::options(),
+            'reactionTypes' => PostReactionType::options(),
             'selectedSpace' => $space->slug,
         ]);
     }

--- a/app/Http/Requests/StorePostReactionRequest.php
+++ b/app/Http/Requests/StorePostReactionRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\PostReactionType;
+use App\Models\Post;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePostReactionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $post = $this->route('post');
+
+        return $post instanceof Post
+            && $this->user()?->can('react', $post) === true;
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', Rule::enum(PostReactionType::class)],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/PostResource.php
+++ b/app/Http/Resources/Api/V1/PostResource.php
@@ -16,6 +16,13 @@ class PostResource extends JsonResource
         /** @var Post $post */
         $post = $this->resource;
         $media = $post->media;
+        /** @var array{like?: int, celebrate?: int, insightful?: int} $reactionCounts */
+        $reactionCounts = $post->getAttribute('reaction_counts') ?? [];
+        $reactionCounts = [
+            'like' => (int) ($reactionCounts['like'] ?? 0),
+            'celebrate' => (int) ($reactionCounts['celebrate'] ?? 0),
+            'insightful' => (int) ($reactionCounts['insightful'] ?? 0),
+        ];
 
         return [
             'id' => (string) $post->getKey(),
@@ -30,6 +37,10 @@ class PostResource extends JsonResource
                 'mime_type' => $media->mime_type,
             ] : null,
             'comments_count' => (int) ($post->getAttribute('comments_count') ?? 0),
+            'reactions' => [
+                'total' => array_sum($reactionCounts),
+                'counts' => $reactionCounts,
+            ],
             'author' => [
                 'handle' => $post->author->handle,
                 'name' => $post->author->name,
@@ -41,6 +52,8 @@ class PostResource extends JsonResource
                 'can_comment' => (bool) $post->getAttribute('viewer_can_comment'),
                 'can_report' => (bool) $post->getAttribute('viewer_can_report'),
                 'has_reported' => (bool) $post->getAttribute('viewer_has_reported'),
+                'can_react' => (bool) $post->getAttribute('viewer_can_react'),
+                'reaction_type' => $post->getAttribute('viewer_reaction_type'),
             ],
         ];
     }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -95,6 +95,12 @@ class Post extends Model
         return $this->hasMany(PostSave::class);
     }
 
+    /** @return HasMany<PostReaction, $this> */
+    public function reactions(): HasMany
+    {
+        return $this->hasMany(PostReaction::class);
+    }
+
     /** @return HasOne<PostMedia, $this> */
     public function media(): HasOne
     {

--- a/app/Models/PostReaction.php
+++ b/app/Models/PostReaction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\PostReactionType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $post_id
+ * @property int $user_id
+ * @property PostReactionType $type
+ * @property-read Post $post
+ */
+class PostReaction extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'post_id',
+        'type',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => PostReactionType::class,
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<Post, $this> */
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -47,6 +47,13 @@ class PostPolicy
             && $this->view($user, $post);
     }
 
+    public function react(User $user, Post $post): bool
+    {
+        return $post->published_at !== null
+            && $post->hidden_at === null
+            && $this->view($user, $post);
+    }
+
     public function update(User $user, Post $post): bool
     {
         return $post->user_id === $user->getKey()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -87,6 +87,9 @@ class AppServiceProvider extends ServiceProvider
         RateLimiter::for('post-saving', fn (Request $request): Limit => Limit::perMinute(60)
             ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
 
+        RateLimiter::for('post-reacting', fn (Request $request): Limit => Limit::perMinute(60)
+            ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
+
         RateLimiter::for('community-search', fn (Request $request): Limit => Limit::perMinute(60)
             ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
 

--- a/database/migrations/2026_07_23_000003_create_post_reactions_table.php
+++ b/database/migrations/2026_07_23_000003_create_post_reactions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('post_reactions', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('type', 24);
+            $table->timestamps();
+
+            $table->unique(['post_id', 'user_id']);
+            $table->index(['post_id', 'type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('post_reactions');
+    }
+};

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -193,6 +193,8 @@ The first resources expose only allowlisted fields:
 - posts and comments exclude storage paths, report details, moderator notes,
   hidden timestamps, and author account identifiers; nullable `edited_at`
   communicates an author change without exposing internal update timestamps;
+  post reactions expose bounded counts and only the current viewer's selected
+  type, never reactor identities;
 - media exposes only the authorized API URL, alt text, normalized dimensions,
   and MIME type;
 - notifications are re-resolved at read time and expose a safe structured

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,7 +14,9 @@ or moderators when a new post or comment report needs attention.
 Both preferences default to enabled and affect new notifications only. Delivery
 uses Laravel's database channel synchronously, so the core experience does not
 require a queue worker. Email, web push, mobile push, digests, mentions, and
-reactions are not part of this release.
+per-reaction notifications are not part of this release. Typed post reactions
+emit `PostReactionChanged` for extensions, but the core deliberately avoids a
+notification for every reaction.
 
 ## Privacy and authorization
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1132,6 +1132,7 @@
           "edited_at",
           "media",
           "comments_count",
+          "reactions",
           "author",
           "space",
           "viewer"
@@ -1169,6 +1170,43 @@
             "type": "integer",
             "minimum": 0
           },
+          "reactions": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "total",
+              "counts"
+            ],
+            "properties": {
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "counts": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "like",
+                  "celebrate",
+                  "insightful"
+                ],
+                "properties": {
+                  "like": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "celebrate": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "insightful": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
           "author": {
             "$ref": "#/components/schemas/ProfileSummary"
           },
@@ -1181,7 +1219,9 @@
             "required": [
               "can_comment",
               "can_report",
-              "has_reported"
+              "has_reported",
+              "can_react",
+              "reaction_type"
             ],
             "properties": {
               "can_comment": {
@@ -1192,6 +1232,21 @@
               },
               "has_reported": {
                 "type": "boolean"
+              },
+              "can_react": {
+                "type": "boolean"
+              },
+              "reaction_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "like",
+                  "celebrate",
+                  "insightful",
+                  null
+                ]
               }
             }
           }

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -10,6 +10,8 @@ The core owns invariants that an extension must not bypass:
 - profile visibility, discovery, mute, and mutual block boundaries;
 - Space visibility, roles, membership, invitations, and ownership;
 - chronological posts and comments;
+- one allowlisted post reaction per member, aggregate-only public projections,
+  and after-transaction reaction change events;
 - post-image ownership, bounded normalization, private storage, parent-policy
   delivery, accessible projections, and lifecycle cleanup;
 - report eligibility, moderation decisions, and append-only audit records;
@@ -51,6 +53,13 @@ checksums, and source metadata remain server-side. Feed, permalink, and profile
 views consume this shared projection; the delivery controller rechecks the parent
 post policy on every request. The full contract is documented in
 [`media.md`](media.md).
+
+Typed post reactions follow the same boundary. The core stores one allowlisted
+reaction per member and post, serializes changes with the parent post, and emits
+`PostReactionChanged` only after a successful write. Feed, permalink, and API
+projections expose aggregate counts plus the current viewer's type; they never
+expose reactor identities. Extensions may listen to the event for analytics or
+batched notifications, but must recheck post visibility before delivery.
 
 ## Near-term contract work
 

--- a/resources/js/components/social/post-reactions.tsx
+++ b/resources/js/components/social/post-reactions.tsx
@@ -1,0 +1,127 @@
+import { router } from '@inertiajs/react';
+import { Heart, Lightbulb, PartyPopper } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { useState } from 'react';
+
+export type ReactionType = {
+    value: string;
+    label: string;
+};
+
+export type ReactionSummary = {
+    total: number;
+    counts: Record<string, number>;
+    viewerType: string | null;
+    canReact: boolean;
+};
+
+const reactionStyles: Record<
+    string,
+    { icon: LucideIcon; active: string; idle: string }
+> = {
+    like: {
+        icon: Heart,
+        active: 'border-rose-500/25 bg-rose-500/10 text-rose-600',
+        idle: 'hover:bg-rose-500/8 hover:text-rose-600',
+    },
+    celebrate: {
+        icon: PartyPopper,
+        active: 'border-amber-500/30 bg-amber-500/12 text-amber-700',
+        idle: 'hover:bg-amber-500/10 hover:text-amber-700',
+    },
+    insightful: {
+        icon: Lightbulb,
+        active: 'border-sky-500/25 bg-sky-500/10 text-sky-700',
+        idle: 'hover:bg-sky-500/8 hover:text-sky-700',
+    },
+};
+
+export function PostReactions({
+    postId,
+    reactions,
+    reactionTypes,
+}: {
+    postId: number;
+    reactions: ReactionSummary;
+    reactionTypes: ReactionType[];
+}) {
+    const [processing, setProcessing] = useState(false);
+
+    if (!reactions.canReact && reactions.total === 0) {
+        return null;
+    }
+
+    const react = (type: string) => {
+        if (!reactions.canReact || processing) {
+            return;
+        }
+
+        const options = {
+            preserveScroll: true,
+            onStart: () => setProcessing(true),
+            onFinish: () => setProcessing(false),
+        };
+
+        if (reactions.viewerType === type) {
+            router.delete(`/posts/${postId}/reaction`, options);
+
+            return;
+        }
+
+        router.put(`/posts/${postId}/reaction`, { type }, options);
+    };
+
+    return (
+        <div
+            className="mt-4 flex flex-wrap items-center gap-1.5 border-t border-border/70 pt-3"
+            aria-label="Post reactions"
+        >
+            {reactionTypes.map((type) => {
+                const selected = reactions.viewerType === type.value;
+                const style = reactionStyles[type.value];
+
+                if (!style) {
+                    return null;
+                }
+
+                const Icon = style.icon;
+                const count = reactions.counts[type.value] ?? 0;
+
+                return (
+                    <button
+                        key={type.value}
+                        type="button"
+                        onClick={() => react(type.value)}
+                        disabled={!reactions.canReact || processing}
+                        aria-pressed={selected}
+                        aria-label={`${type.label}${count > 0 ? `, ${count}` : ''}`}
+                        className={`social-focus inline-flex min-h-10 items-center gap-1.5 rounded-xl border px-3 text-xs font-extrabold transition-colors disabled:cursor-not-allowed disabled:opacity-55 ${
+                            selected
+                                ? style.active
+                                : `border-transparent text-muted-foreground ${style.idle}`
+                        }`}
+                    >
+                        <Icon
+                            className={`size-4 ${selected && type.value === 'like' ? 'fill-current' : ''}`}
+                            aria-hidden="true"
+                        />
+                        <span>{type.label}</span>
+                        {count > 0 && (
+                            <span
+                                className={`tabular-nums ${selected ? 'text-current' : 'text-foreground/75'}`}
+                            >
+                                {count.toLocaleString()}
+                            </span>
+                        )}
+                    </button>
+                );
+            })}
+            {reactions.total > 0 && (
+                <span className="ml-auto px-2 text-[0.7rem] font-semibold text-muted-foreground">
+                    {reactions.total.toLocaleString()}{' '}
+                    {reactions.total === 1 ? 'reaction' : 'reactions'}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/feed/index.tsx
+++ b/resources/js/pages/feed/index.tsx
@@ -23,6 +23,11 @@ import type { SocialComment } from '@/components/social/comment-thread';
 import { CommunitySignal } from '@/components/social/community-signal';
 import { PostImage } from '@/components/social/post-image';
 import type { PostMedia } from '@/components/social/post-image';
+import { PostReactions } from '@/components/social/post-reactions';
+import type {
+    ReactionSummary,
+    ReactionType,
+} from '@/components/social/post-reactions';
 import { SpaceCover } from '@/components/social/space-cover';
 import { Button } from '@/components/ui/button';
 import { useClipboard } from '@/hooks/use-clipboard';
@@ -52,6 +57,7 @@ type FeedPost = {
     canDelete: boolean;
     hasReported: boolean;
     isSaved: boolean;
+    reactions: ReactionSummary;
     commentsCount: number;
     comments: SocialComment[];
     author: { name: string; handle: string; profileVisible: boolean };
@@ -67,6 +73,7 @@ type FeedProps = {
     spaces: Space[];
     posts: FeedPost[];
     reportReasons: ReportReason[];
+    reactionTypes: ReactionType[];
     selectedSpace: string | null;
     viewMode?: 'feed' | 'saved';
     status?: string;
@@ -357,9 +364,11 @@ function Composer({ spaces }: { spaces: Space[] }) {
 function PostCard({
     item,
     reportReasons,
+    reactionTypes,
 }: {
     item: FeedPost;
     reportReasons: ReportReason[];
+    reactionTypes: ReactionType[];
 }) {
     const [reporting, setReporting] = useState(false);
     const [copyFeedback, setCopyFeedback] = useState(false);
@@ -426,7 +435,7 @@ function PostCard({
 
     return (
         <article className="social-card rounded-[1.35rem] p-4 sm:p-5">
-            <header className="flex items-start gap-3">
+            <header className="flex flex-wrap items-start gap-3">
                 <AvatarMark name={item.author.name} className="size-11" />
                 <div className="min-w-0 flex-1">
                     <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
@@ -469,7 +478,7 @@ function PostCard({
                         )}
                     </Link>
                 </div>
-                <div className="flex shrink-0 flex-wrap items-center gap-2">
+                <div className="flex w-full flex-wrap items-center gap-1 border-t border-border/60 pt-2 sm:w-auto sm:shrink-0 sm:gap-2 sm:border-0 sm:pt-0">
                     <AuthoredContentMenu
                         body={item.body}
                         canEdit={item.canEdit}
@@ -551,6 +560,11 @@ function PostCard({
                 </button>
             )}
             {item.media && <PostImage media={item.media} className="mt-4" />}
+            <PostReactions
+                postId={item.id}
+                reactions={item.reactions}
+                reactionTypes={reactionTypes}
+            />
             {reporting && (
                 <form
                     onSubmit={submitReport}
@@ -721,6 +735,7 @@ export default function Feed({
     spaces,
     posts,
     reportReasons,
+    reactionTypes,
     selectedSpace,
     viewMode = 'feed',
     status,
@@ -873,6 +888,7 @@ export default function Feed({
                                         key={item.id}
                                         item={item}
                                         reportReasons={reportReasons}
+                                        reactionTypes={reactionTypes}
                                     />
                                 ))
                             )}

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -26,6 +26,11 @@ import type {
 import { CommunitySignal } from '@/components/social/community-signal';
 import { PostImage } from '@/components/social/post-image';
 import type { PostMedia } from '@/components/social/post-image';
+import { PostReactions } from '@/components/social/post-reactions';
+import type {
+    ReactionSummary,
+    ReactionType,
+} from '@/components/social/post-reactions';
 import { SpaceCover } from '@/components/social/space-cover';
 import { Button } from '@/components/ui/button';
 import { useClipboard } from '@/hooks/use-clipboard';
@@ -40,6 +45,7 @@ type ConversationPost = {
     isDraft: boolean;
     isHidden: boolean;
     isSaved: boolean;
+    reactions: ReactionSummary;
     canComment: boolean;
     canReport: boolean;
     canEdit: boolean;
@@ -74,6 +80,7 @@ type ShowPostProps = {
     post: ConversationPost;
     comments: ConversationPage;
     reportReasons: ReportReason[];
+    reactionTypes: ReactionType[];
     status?: string;
 };
 
@@ -94,6 +101,7 @@ export default function ShowPost({
     post,
     comments,
     reportReasons,
+    reactionTypes,
     status,
 }: ShowPostProps) {
     const [reporting, setReporting] = useState(false);
@@ -226,7 +234,7 @@ export default function ShowPost({
                                 </div>
                             )}
                             <div className="p-4 sm:p-5">
-                                <header className="flex items-start gap-3">
+                                <header className="flex flex-wrap items-start gap-3">
                                     <AvatarMark
                                         name={post.author.name}
                                         className="size-11"
@@ -272,7 +280,7 @@ export default function ShowPost({
                                             </Link>
                                         </div>
                                     </div>
-                                    <div className="flex shrink-0 flex-wrap items-center gap-2">
+                                    <div className="flex w-full flex-wrap items-center gap-1 border-t border-border/60 pt-2 sm:w-auto sm:shrink-0 sm:gap-2 sm:border-0 sm:pt-0">
                                         <AuthoredContentMenu
                                             body={post.body}
                                             canEdit={post.canEdit}
@@ -355,6 +363,11 @@ export default function ShowPost({
                                         eager
                                     />
                                 )}
+                                <PostReactions
+                                    postId={post.id}
+                                    reactions={post.reactions}
+                                    reactionTypes={reactionTypes}
+                                />
 
                                 {reporting && (
                                     <form

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\PeopleController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\PostImageController;
+use App\Http\Controllers\PostReactionController;
 use App\Http\Controllers\PostReportController;
 use App\Http\Controllers\PostReportModerationController;
 use App\Http\Controllers\SavedPostController;
@@ -124,6 +125,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('posts/{post}/save', [SavedPostController::class, 'destroy'])
         ->middleware('throttle:post-saving')
         ->name('posts.saves.destroy');
+    Route::put('posts/{post}/reaction', [PostReactionController::class, 'store'])
+        ->middleware('throttle:post-reacting')
+        ->name('posts.reactions.store');
+    Route::delete('posts/{post}/reaction', [PostReactionController::class, 'destroy'])
+        ->middleware('throttle:post-reacting')
+        ->name('posts.reactions.destroy');
     Route::post('posts/{post}/comments', [CommentController::class, 'store'])
         ->middleware('throttle:comment-publishing')
         ->name('posts.comments.store');

--- a/tests/Feature/Api/FeedTest.php
+++ b/tests/Feature/Api/FeedTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Feature\Api;
 
+use App\Enums\PostReactionType;
 use App\Enums\ProfileVisibility;
 use App\Enums\UserRelationshipType;
 use App\Models\Comment;
 use App\Models\Post;
+use App\Models\PostReaction;
 use App\Models\PostReport;
 use App\Models\Space;
 use App\Models\User;
@@ -63,6 +65,11 @@ class FeedTest extends TestCase
             'post_id' => $olderPublic->getKey(),
             'reporter_id' => $viewer->getKey(),
         ]);
+        PostReaction::query()->create([
+            'post_id' => $olderPublic->getKey(),
+            'user_id' => $viewer->getKey(),
+            'type' => PostReactionType::Insightful,
+        ]);
 
         Post::factory()->for($public)->for($publicAuthor, 'author')->create([
             'body' => 'Draft post',
@@ -103,6 +110,9 @@ class FeedTest extends TestCase
             ->assertJsonPath('data.0.space.viewer.is_member', true)
             ->assertJsonPath('data.1.id', (string) $olderPublic->getKey())
             ->assertJsonPath('data.1.comments_count', 1)
+            ->assertJsonPath('data.1.reactions.total', 1)
+            ->assertJsonPath('data.1.reactions.counts.insightful', 1)
+            ->assertJsonPath('data.1.viewer.reaction_type', PostReactionType::Insightful->value)
             ->assertJsonPath('data.1.author.profile_visible', false)
             ->assertJsonPath('data.1.viewer.can_comment', false)
             ->assertJsonPath('data.1.viewer.can_report', true)
@@ -119,12 +129,16 @@ class FeedTest extends TestCase
             ->assertHeader('X-RateLimit-Limit', '120');
 
         $this->assertSame(
-            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
             array_keys($response->json('data.0')),
         );
         $this->assertSame(
             ['handle', 'name', 'headline', 'profile_visible'],
             array_keys($response->json('data.0.author')),
+        );
+        $this->assertSame(
+            ['can_comment', 'can_report', 'has_reported', 'can_react', 'reaction_type'],
+            array_keys($response->json('data.0.viewer')),
         );
     }
 

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature\Api;
 
+use App\Enums\PostReactionType;
 use App\Enums\ProfileVisibility;
 use App\Enums\UserRelationshipType;
 use App\Models\Comment;
 use App\Models\CommentReport;
 use App\Models\Post;
+use App\Models\PostReaction;
 use App\Models\PostReport;
 use App\Models\Space;
 use App\Models\User;
@@ -67,6 +69,11 @@ class PostApiTest extends TestCase
             'post_id' => $post->getKey(),
             'reporter_id' => $viewer->getKey(),
         ]);
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $viewer->getKey(),
+            'type' => PostReactionType::Celebrate,
+        ]);
 
         $response = $this->getWithToken($viewer)
             ->getJson(route('api.v1.posts.show', $post));
@@ -76,6 +83,9 @@ class PostApiTest extends TestCase
             ->assertJsonPath('data.id', (string) $post->getKey())
             ->assertJsonPath('data.body', 'A stable post for API readers.')
             ->assertJsonPath('data.comments_count', 1)
+            ->assertJsonPath('data.reactions.total', 1)
+            ->assertJsonPath('data.reactions.counts.celebrate', 1)
+            ->assertJsonPath('data.viewer.reaction_type', PostReactionType::Celebrate->value)
             ->assertJsonPath('data.author.profile_visible', true)
             ->assertJsonPath('data.space.slug', $space->slug)
             ->assertJsonPath('data.viewer.can_comment', true)
@@ -91,7 +101,7 @@ class PostApiTest extends TestCase
             ->assertJsonMissingPath('data.media.author_id');
 
         $this->assertSame(
-            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
             array_keys($response->json('data')),
         );
         $this->assertSame(

--- a/tests/Feature/PostReactionTest.php
+++ b/tests/Feature/PostReactionTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PostReactionType;
+use App\Enums\UserRelationshipType;
+use App\Events\PostReactionChanged;
+use App\Models\Post;
+use App\Models\PostReaction;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class PostReactionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_visible_post_reaction_is_idempotent_and_can_change_type(): void
+    {
+        Event::fake([PostReactionChanged::class]);
+
+        $viewer = User::factory()->create();
+        $post = Post::factory()->create();
+
+        $this->actingAs($viewer)
+            ->put(route('posts.reactions.store', $post), [
+                'type' => PostReactionType::Like->value,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Reaction added.');
+
+        $this->actingAs($viewer)
+            ->put(route('posts.reactions.store', $post), [
+                'type' => PostReactionType::Like->value,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Reaction unchanged.');
+
+        $this->actingAs($viewer)
+            ->put(route('posts.reactions.store', $post), [
+                'type' => PostReactionType::Insightful->value,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Reaction updated.');
+
+        $this->assertDatabaseCount('post_reactions', 1);
+        $this->assertDatabaseHas('post_reactions', [
+            'post_id' => $post->getKey(),
+            'user_id' => $viewer->getKey(),
+            'type' => PostReactionType::Insightful->value,
+        ]);
+        Event::assertDispatchedTimes(PostReactionChanged::class, 2);
+        Event::assertDispatched(
+            PostReactionChanged::class,
+            fn (PostReactionChanged $event): bool => $event->post->is($post)
+                && $event->user->is($viewer)
+                && $event->previousType === PostReactionType::Like
+                && $event->type === PostReactionType::Insightful,
+        );
+    }
+
+    public function test_reaction_type_is_allowlisted_and_visibility_is_enforced(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create();
+        $public = Space::factory()->create();
+        $private = Space::factory()->private()->create();
+        $visible = Post::factory()->for($public)->for($author, 'author')->create();
+        $draft = Post::factory()->for($public)->for($author, 'author')->create([
+            'published_at' => null,
+        ]);
+        $hidden = Post::factory()->for($public)->for($author, 'author')->create([
+            'hidden_at' => now(),
+        ]);
+        $privatePost = Post::factory()->for($private)->for($author, 'author')->create();
+
+        $this->actingAs($viewer)
+            ->put(route('posts.reactions.store', $visible), ['type' => 'custom'])
+            ->assertSessionHasErrors('type');
+
+        foreach ([$draft, $hidden, $privatePost] as $post) {
+            $this->actingAs($viewer)
+                ->put(route('posts.reactions.store', $post), [
+                    'type' => PostReactionType::Celebrate->value,
+                ])
+                ->assertForbidden();
+        }
+
+        $viewer->outgoingRelationships()->create([
+            'target_id' => $author->getKey(),
+            'type' => UserRelationshipType::Block,
+        ]);
+
+        $this->actingAs($viewer)
+            ->put(route('posts.reactions.store', $visible), [
+                'type' => PostReactionType::Celebrate->value,
+            ])
+            ->assertForbidden();
+
+        $this->assertDatabaseEmpty('post_reactions');
+    }
+
+    public function test_removal_only_deletes_the_viewers_reaction_even_after_visibility_changes(): void
+    {
+        Event::fake([PostReactionChanged::class]);
+
+        $viewer = User::factory()->create();
+        $other = User::factory()->create();
+        $post = Post::factory()->create();
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $viewer->getKey(),
+            'type' => PostReactionType::Like,
+        ]);
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $other->getKey(),
+            'type' => PostReactionType::Celebrate,
+        ]);
+        $post->update(['hidden_at' => now()]);
+
+        $this->actingAs($viewer)
+            ->delete(route('posts.reactions.destroy', $post))
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Reaction removed.');
+
+        $this->assertDatabaseMissing('post_reactions', [
+            'post_id' => $post->getKey(),
+            'user_id' => $viewer->getKey(),
+        ]);
+        $this->assertDatabaseHas('post_reactions', [
+            'post_id' => $post->getKey(),
+            'user_id' => $other->getKey(),
+        ]);
+        Event::assertDispatched(
+            PostReactionChanged::class,
+            fn (PostReactionChanged $event): bool => $event->previousType === PostReactionType::Like
+                && $event->type === null,
+        );
+
+        $this->actingAs($viewer)
+            ->delete('/posts/999999/reaction')
+            ->assertRedirect()
+            ->assertSessionHas('status', 'No reaction to remove.');
+    }
+
+    public function test_feed_and_permalink_expose_only_bounded_aggregates_and_viewer_state(): void
+    {
+        $viewer = User::factory()->create();
+        $other = User::factory()->create();
+        $third = User::factory()->create();
+        $post = Post::factory()->create();
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $viewer->getKey(),
+            'type' => PostReactionType::Insightful,
+        ]);
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $other->getKey(),
+            'type' => PostReactionType::Like,
+        ]);
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $third->getKey(),
+            'type' => PostReactionType::Like,
+        ]);
+
+        $assertReactionProjection = fn (Assert $page): Assert => $page
+            ->where('reactionTypes.0.value', PostReactionType::Like->value)
+            ->where('posts.0.reactions.total', 3)
+            ->where('posts.0.reactions.counts.like', 2)
+            ->where('posts.0.reactions.counts.celebrate', 0)
+            ->where('posts.0.reactions.counts.insightful', 1)
+            ->where('posts.0.reactions.viewerType', PostReactionType::Insightful->value)
+            ->missing('posts.0.reactions.users');
+
+        $this->actingAs($viewer)
+            ->get(route('feed'))
+            ->assertOk()
+            ->assertInertia($assertReactionProjection);
+
+        $this->actingAs($viewer)
+            ->get(route('posts.show', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('reactionTypes.2.value', PostReactionType::Insightful->value)
+                ->where('post.reactions.total', 3)
+                ->where('post.reactions.counts.like', 2)
+                ->where('post.reactions.viewerType', PostReactionType::Insightful->value)
+                ->missing('post.reactions.users'));
+    }
+
+    public function test_post_and_user_deletion_cascade_reactions(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create();
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $user->getKey(),
+            'type' => PostReactionType::Like,
+        ]);
+
+        $user->delete();
+        $this->assertDatabaseEmpty('post_reactions');
+
+        $secondUser = User::factory()->create();
+        PostReaction::query()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $secondUser->getKey(),
+            'type' => PostReactionType::Like,
+        ]);
+        $post->delete();
+
+        $this->assertDatabaseEmpty('post_reactions');
+    }
+}

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -143,7 +143,7 @@ class ApiContractDocumentationTest extends TestCase
             array_keys($schemas['Space']['properties']),
         );
         $this->assertSame(
-            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'author', 'space', 'viewer'],
+            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
             array_keys($schemas['Post']['properties']),
         );
         $this->assertSame(


### PR DESCRIPTION
## Why

Members need a lightweight way to respond without turning the core into a noisy engagement system or exposing reactor identities.

## What changed

- adds one allowlisted Like, Celebrate, or Insightful reaction per member and post
- makes add, change, and removal idempotent and serialized with the parent post
- exposes aggregate counts plus only the current viewer state in web and API projections
- emits an after-write `PostReactionChanged` extension event without enabling per-reaction core notifications
- adds a responsive reaction row and fixes cramped mobile post actions
- updates the OpenAPI and architecture contracts

## Validation

- `php artisan test` — 170 tests, 1,804 assertions
- Pint, PHPStan, ESLint, Prettier, and TypeScript checks passed
- production Vite build passed
- Composer and production npm audits found no known vulnerabilities
- browser-tested add, change, permalink persistence, and removal on desktop and at 390px mobile width