### PR TITLE
Expose author controls on profile activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ All notable project changes will be documented here.
 
 ### Changed
 
+- Own-profile activity cards now expose the existing author edit and delete
+  controls while preserving active moderation-review locks.
 - Dependabot now groups only compatible minor and patch dependency updates;
   major upgrades remain isolated for focused review.
 - Mobile Space pulse cards now separate cover imagery from their text content,

--- a/app/Http/Controllers/PeopleController.php
+++ b/app/Http/Controllers/PeopleController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Community\PostMediaView;
+use App\Enums\ReportStatus;
 use App\Models\Post;
+use App\Models\PostReport;
 use App\Models\Space;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -88,16 +90,33 @@ class PeopleController extends Controller
 
         $postCount = (clone $visiblePosts)->count();
 
-        $posts = $visiblePosts
+        $postModels = $visiblePosts
             ->with(['space:id,name,slug', 'media'])
             ->latest('published_at')
             ->limit(12)
-            ->get()
+            ->get();
+
+        $lockedPostIds = PostReport::query()
+            ->whereIn('post_id', $postModels->modelKeys())
+            ->whereIn('status', [
+                ReportStatus::Open->value,
+                ReportStatus::Reviewing->value,
+            ])
+            ->pluck('post_id')
+            ->all();
+
+        $posts = $postModels
             ->map(fn (Post $post): array => [
                 'id' => $post->id,
+                'url' => route('posts.show', $post),
                 'body' => $post->body,
                 'media' => $media->for($post),
                 'publishedAt' => $post->published_at?->toIso8601String(),
+                'editedAt' => $post->edited_at?->toIso8601String(),
+                'canEdit' => Gate::forUser($viewer)->allows('update', $post)
+                    && ! in_array($post->getKey(), $lockedPostIds, true),
+                'canDelete' => Gate::forUser($viewer)->allows('delete', $post)
+                    && ! in_array($post->getKey(), $lockedPostIds, true),
                 'space' => [
                     'name' => $post->space->name,
                     'slug' => $post->space->slug,

--- a/resources/js/pages/people/show.tsx
+++ b/resources/js/pages/people/show.tsx
@@ -8,6 +8,7 @@ import {
     Settings,
     UsersRound,
 } from 'lucide-react';
+import { AuthoredContentMenu } from '@/components/social/authored-content-menu';
 import { AvatarMark } from '@/components/social/avatar-mark';
 import { PostImage } from '@/components/social/post-image';
 import type { PostMedia } from '@/components/social/post-image';
@@ -46,9 +47,13 @@ type ProfileSpace = {
 
 type ProfilePost = {
     id: number;
+    url: string;
     body: string;
     media: PostMedia | null;
     publishedAt: string | null;
+    editedAt: string | null;
+    canEdit: boolean;
+    canDelete: boolean;
     space: { name: string; slug: string };
 };
 
@@ -419,7 +424,7 @@ export default function ShowProfile({
                                         key={post.id}
                                         className="social-card rounded-[1.45rem] p-4 sm:p-5"
                                     >
-                                        <header className="flex items-center gap-3">
+                                        <header className="flex items-start gap-3">
                                             <AvatarMark
                                                 name={profile.name}
                                                 className="size-10"
@@ -428,7 +433,7 @@ export default function ShowProfile({
                                                 <p className="truncate text-sm font-extrabold">
                                                     {profile.name}
                                                 </p>
-                                                <div className="flex flex-wrap gap-x-1.5 text-xs font-semibold text-muted-foreground">
+                                                <div className="flex flex-wrap items-center gap-x-1.5 text-xs font-semibold text-muted-foreground">
                                                     <Link
                                                         href={`/spaces/${post.space.slug}`}
                                                         className="text-primary hover:underline"
@@ -438,18 +443,41 @@ export default function ShowProfile({
                                                     <span aria-hidden="true">
                                                         ·
                                                     </span>
-                                                    <time
-                                                        dateTime={
-                                                            post.publishedAt ??
-                                                            undefined
-                                                        }
+                                                    <Link
+                                                        href={post.url}
+                                                        className="social-focus rounded-md hover:text-foreground"
                                                     >
-                                                        {postDate(
-                                                            post.publishedAt,
-                                                        )}
-                                                    </time>
+                                                        <time
+                                                            dateTime={
+                                                                post.publishedAt ??
+                                                                undefined
+                                                            }
+                                                        >
+                                                            {postDate(
+                                                                post.publishedAt,
+                                                            )}
+                                                        </time>
+                                                    </Link>
+                                                    {post.editedAt && (
+                                                        <>
+                                                            <span aria-hidden="true">
+                                                                ·
+                                                            </span>
+                                                            <span>Edited</span>
+                                                        </>
+                                                    )}
                                                 </div>
                                             </div>
+                                            <AuthoredContentMenu
+                                                body={post.body}
+                                                canEdit={post.canEdit}
+                                                canDelete={post.canDelete}
+                                                contentType="post"
+                                                updateUrl={`/posts/${post.id}`}
+                                                deleteUrl={`/posts/${post.id}`}
+                                                maxLength={2000}
+                                                compact
+                                            />
                                         </header>
                                         <p className="mt-4 text-[1.01rem] leading-7 whitespace-pre-wrap text-foreground/90">
                                             {post.body}

--- a/tests/Feature/AuthoredContentManagementTest.php
+++ b/tests/Feature/AuthoredContentManagementTest.php
@@ -46,6 +46,48 @@ class AuthoredContentManagementTest extends TestCase
                 ->where('posts.0.editedAt', $post->edited_at?->toIso8601String()));
     }
 
+    public function test_profile_activity_exposes_author_controls_and_respects_moderation_locks(): void
+    {
+        $author = User::factory()->create();
+        $reporter = User::factory()->create();
+        $space = Space::factory()->create();
+        $space->addMember($author);
+        $space->addMember($reporter);
+        $editablePost = Post::factory()->for($space)->for($author, 'author')->create([
+            'body' => 'Editable profile post',
+        ]);
+        $lockedPost = Post::factory()->for($space)->for($author, 'author')->create([
+            'body' => 'Post under review',
+            'published_at' => now()->subMinute(),
+        ]);
+
+        PostReport::factory()
+            ->for($space)
+            ->for($lockedPost)
+            ->for($reporter, 'reporter')
+            ->create(['status' => ReportStatus::Reviewing]);
+
+        $this->actingAs($author)
+            ->get(route('people.show', $author))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('posts.0.id', $editablePost->getKey())
+                ->where('posts.0.canEdit', true)
+                ->where('posts.0.canDelete', true)
+                ->where('posts.1.id', $lockedPost->getKey())
+                ->where('posts.1.canEdit', false)
+                ->where('posts.1.canDelete', false));
+
+        $this->actingAs($reporter)
+            ->get(route('people.show', $author))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('posts.0.canEdit', false)
+                ->where('posts.0.canDelete', false)
+                ->where('posts.1.canEdit', false)
+                ->where('posts.1.canDelete', false));
+    }
+
     public function test_author_can_edit_a_comment_and_the_conversation_receives_author_controls(): void
     {
         $author = User::factory()->create();


### PR DESCRIPTION
Profile activity cards showed a member’s posts but omitted the author controls already available in the feed and conversation view. This made basic edit and delete actions look unavailable from the member’s own profile.

This change reuses the existing author menu on profile posts, links timestamps to the full conversation, exposes edited state, and keeps ownership and active moderation-review locks enforced server-side.

Validated with:
- full project CI: 178 tests / 1,918 assertions, Pint, PHPStan, ESLint, Prettier, and TypeScript
- production asset build
- Composer and npm security audits
- mobile and desktop browser checks of edit/delete dialogs with no console warnings or errors