### PR TITLE
Add privacy-safe mentions for posts and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable project changes will be documented here.
 
 ### Added
 
+- Privacy-safe `@handle` mentions for posts and comments, including bounded
+  case-insensitive parsing, viewer-resolved links across web and API surfaces,
+  deduplicated low-data notifications, per-member preferences, edit-aware
+  delivery, and access revalidation.
 - Participant-only direct messages with one canonical thread per member pair,
   privacy-aware conversation start, block-enforced sending, owner-scoped unread
   state, bounded history, rate limits, and responsive inbox/thread views.
@@ -39,7 +43,8 @@ All notable project changes will be documented here.
 /api/v1/notifications/{notification}/read` and `PATCH
 /api/v1/notifications/read-all`, preserving owner scope and policy-safe
   mark-read behavior.
-- Per-member preferences for reply and moderation notification categories.
+- Per-member preferences for reply, mention, and moderation notification
+  categories.
 - Cursor-paginated post detail and comments APIs for native clients with
   policy-enforced access: `GET /api/v1/posts/{post}` and
   `GET /api/v1/posts/{post}/comments`.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
   aggregate-only counts, and a responsive feed/permalink interaction.
 - Membership-protected comments with compact feed previews, permanent post
   links, and a full visibility-filtered paginated conversation view.
+- Privacy-safe `@handle` mentions in posts and comments, with bounded parsing,
+  viewer-resolved profile links, deduplicated alerts, and access rechecked when
+  a notification is opened.
 - Author-controlled editing and deletion for posts and comments, with visible
   edited state and content changes locked while an active moderation review is
   in progress.
@@ -128,8 +131,9 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
   policy-protected delivery, and metadata-stripping WebP normalization.
 - Private post and comment reporting with allowlisted reasons, duplicate protection, and separate rate limits.
 - A unified, policy-backed moderator queue with documented decisions, content hide/restore behavior, and append-only Space audit entries.
-- A low-noise in-app notification center for replies and new moderation reports,
-  with per-category preferences, unread state, and access rechecked when opened.
+- A low-noise in-app notification center for replies, direct mentions, and new
+  moderation reports, with per-category preferences, unread state, and access
+  rechecked when opened.
 - Participant-only direct messages with one canonical conversation per member
   pair, owner-scoped unread state, block-aware sending, bounded history, and
   responsive inbox/thread views.

--- a/app/Community/CommunityFeed.php
+++ b/app/Community/CommunityFeed.php
@@ -2,6 +2,7 @@
 
 namespace App\Community;
 
+use App\Community\Mentions\MentionProjection;
 use App\Enums\ReportStatus;
 use App\Enums\SpaceRole;
 use App\Enums\UserRelationshipType;
@@ -19,6 +20,7 @@ final class CommunityFeed
     public function __construct(
         private readonly PostMediaView $media,
         private readonly PostReactionProjection $reactions,
+        private readonly MentionProjection $mentions,
     ) {}
 
     /**
@@ -145,6 +147,10 @@ final class CommunityFeed
         $reactionProjection = $this->reactions->forPosts($posts, $user);
 
         $comments = $posts->flatMap(fn (Post $post) => $post->comments);
+        $resolvedMentions = $this->mentions->resolve(
+            $user,
+            $posts->pluck('body')->merge($comments->pluck('body')),
+        );
         $visibleAuthorIds = User::query()
             ->visibleTo($user)
             ->whereKey($posts->pluck('user_id')->merge($comments->pluck('user_id'))->unique())
@@ -188,6 +194,7 @@ final class CommunityFeed
                 'id' => $post->id,
                 'url' => route('posts.show', $post),
                 'body' => $post->body,
+                'mentions' => $this->mentions->forBody($post->body, $resolvedMentions),
                 'media' => $this->media->for($post),
                 'publishedAt' => $post->published_at?->toIso8601String(),
                 'editedAt' => $post->edited_at?->toIso8601String(),
@@ -206,6 +213,7 @@ final class CommunityFeed
                     ->map(fn (Comment $comment): array => [
                         'id' => $comment->getKey(),
                         'body' => $comment->body,
+                        'mentions' => $this->mentions->forBody($comment->body, $resolvedMentions),
                         'publishedAt' => $comment->published_at->toIso8601String(),
                         'editedAt' => $comment->edited_at?->toIso8601String(),
                         'canReport' => $comment->user_id !== $user->getKey(),

--- a/app/Community/ManageAuthoredContent.php
+++ b/app/Community/ManageAuthoredContent.php
@@ -2,6 +2,8 @@
 
 namespace App\Community;
 
+use App\Community\Mentions\MentionNotifier;
+use App\Community\Mentions\MentionParser;
 use App\Enums\ReportStatus;
 use App\Models\Comment;
 use App\Models\Post;
@@ -12,9 +14,14 @@ use Illuminate\Validation\ValidationException;
 
 final class ManageAuthoredContent
 {
+    public function __construct(
+        private readonly MentionParser $mentionParser,
+        private readonly MentionNotifier $mentionNotifier,
+    ) {}
+
     public function updatePost(User $author, Post $post, string $body): bool
     {
-        return DB::transaction(function () use ($author, $post, $body): bool {
+        $result = DB::transaction(function () use ($author, $post, $body): array {
             $lockedPost = Post::query()
                 ->whereKey($post->getKey())
                 ->lockForUpdate()
@@ -24,14 +31,23 @@ final class ManageAuthoredContent
             $this->ensurePostIsNotUnderReview($lockedPost);
 
             if ($lockedPost->body === $body) {
-                return false;
+                return ['changed' => false, 'previousHandles' => []];
             }
 
-            return $lockedPost->update([
+            $previousHandles = $this->mentionParser->handles($lockedPost->body);
+            $changed = $lockedPost->update([
                 'body' => $body,
                 'edited_at' => now(),
             ]);
+
+            return compact('changed', 'previousHandles');
         });
+
+        if ($result['changed']) {
+            $this->mentionNotifier->forPost($post->refresh(), $result['previousHandles']);
+        }
+
+        return $result['changed'];
     }
 
     public function deletePost(User $author, Post $post): void
@@ -50,7 +66,7 @@ final class ManageAuthoredContent
 
     public function updateComment(User $author, Comment $comment, string $body): bool
     {
-        return DB::transaction(function () use ($author, $comment, $body): bool {
+        $result = DB::transaction(function () use ($author, $comment, $body): array {
             $lockedComment = Comment::query()
                 ->with('post')
                 ->whereKey($comment->getKey())
@@ -61,14 +77,23 @@ final class ManageAuthoredContent
             $this->ensureCommentIsNotUnderReview($lockedComment);
 
             if ($lockedComment->body === $body) {
-                return false;
+                return ['changed' => false, 'previousHandles' => []];
             }
 
-            return $lockedComment->update([
+            $previousHandles = $this->mentionParser->handles($lockedComment->body);
+            $changed = $lockedComment->update([
                 'body' => $body,
                 'edited_at' => now(),
             ]);
+
+            return compact('changed', 'previousHandles');
         });
+
+        if ($result['changed']) {
+            $this->mentionNotifier->forComment($comment->refresh(), $result['previousHandles']);
+        }
+
+        return $result['changed'];
     }
 
     public function deleteComment(User $author, Comment $comment): void

--- a/app/Community/Mentions/MentionNotifier.php
+++ b/app/Community/Mentions/MentionNotifier.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Community\Mentions;
+
+use App\Models\Comment;
+use App\Models\NotificationPreference;
+use App\Models\Post;
+use App\Models\User;
+use App\Notifications\ContentMentionNotification;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Notification;
+
+final class MentionNotifier
+{
+    public function __construct(private readonly MentionParser $parser) {}
+
+    /** @param list<string> $previousHandles */
+    public function forPost(Post $post, array $previousHandles = []): void
+    {
+        $post->loadMissing(['author', 'space']);
+        $handles = $this->newHandles($post->body, $previousHandles);
+        $recipients = $this->recipients($post->author, $handles)
+            ->filter(fn (User $recipient): bool => Gate::forUser($recipient)->allows('view', $post));
+
+        Notification::send(
+            $recipients,
+            ContentMentionNotification::forPost($post),
+        );
+    }
+
+    /** @param list<string> $previousHandles */
+    public function forComment(Comment $comment, array $previousHandles = []): void
+    {
+        $comment->loadMissing(['author', 'post.author', 'post.space']);
+        $handles = $this->newHandles($comment->body, $previousHandles);
+        $recipients = $this->recipients($comment->author, $handles)
+            ->filter(function (User $recipient) use ($comment): bool {
+                if (Gate::forUser($recipient)->denies('view', $comment)) {
+                    return false;
+                }
+
+                if (! $recipient->is($comment->post->author)) {
+                    return true;
+                }
+
+                $recipient->loadMissing('notificationPreference');
+
+                return $recipient->notificationPreference instanceof NotificationPreference
+                    && ! $recipient->notificationPreference->comment_replies;
+            });
+
+        Notification::send(
+            $recipients,
+            ContentMentionNotification::forComment($comment),
+        );
+    }
+
+    /**
+     * @param  list<string>  $handles
+     * @return Collection<int, User>
+     */
+    private function recipients(User $author, array $handles): Collection
+    {
+        if ($handles === []) {
+            return new Collection;
+        }
+
+        return User::query()
+            ->visibleTo($author)
+            ->whereKeyNot($author->getKey())
+            ->whereIn('handle', $handles)
+            ->with('notificationPreference')
+            ->get()
+            ->filter(fn (User $recipient): bool => ! $recipient->hasMuted($author)
+                && (! $recipient->notificationPreference instanceof NotificationPreference
+                    || $recipient->notificationPreference->content_mentions));
+    }
+
+    /**
+     * @param  list<string>  $previousHandles
+     * @return list<string>
+     */
+    private function newHandles(string $body, array $previousHandles): array
+    {
+        return array_values(array_diff(
+            $this->parser->handles($body),
+            $previousHandles,
+        ));
+    }
+}

--- a/app/Community/Mentions/MentionParser.php
+++ b/app/Community/Mentions/MentionParser.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Community\Mentions;
+
+final class MentionParser
+{
+    public const MAX_MENTIONS = 10;
+
+    /** @return list<string> */
+    public function handles(string $body): array
+    {
+        preg_match_all(
+            '/(?<![a-z0-9._\/@-])@([a-z0-9]+(?:-[a-z0-9]+)*)\b/i',
+            $body,
+            $matches,
+        );
+
+        $handles = [];
+
+        foreach ($matches[1] as $match) {
+            $handle = strtolower($match);
+
+            if (strlen($handle) < 3
+                || strlen($handle) > 40
+                || in_array($handle, $handles, true)) {
+                continue;
+            }
+
+            $handles[] = $handle;
+
+            if (count($handles) === self::MAX_MENTIONS) {
+                break;
+            }
+        }
+
+        return $handles;
+    }
+}

--- a/app/Community/Mentions/MentionProjection.php
+++ b/app/Community/Mentions/MentionProjection.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Community\Mentions;
+
+use App\Models\User;
+
+final class MentionProjection
+{
+    public function __construct(private readonly MentionParser $parser) {}
+
+    /**
+     * Resolve all profiles that the current viewer may open in one query.
+     *
+     * @param  iterable<string>  $bodies
+     * @return array<string, array{handle: string, name: string, url: string}>
+     */
+    public function resolve(User $viewer, iterable $bodies): array
+    {
+        $handles = [];
+
+        foreach ($bodies as $body) {
+            foreach ($this->parser->handles($body) as $handle) {
+                $handles[$handle] = true;
+            }
+        }
+
+        if ($handles === []) {
+            return [];
+        }
+
+        return User::query()
+            ->visibleTo($viewer)
+            ->whereIn('handle', array_keys($handles))
+            ->get(['id', 'name', 'handle'])
+            ->mapWithKeys(fn (User $user): array => [
+                $user->handle => [
+                    'handle' => $user->handle,
+                    'name' => $user->name,
+                    'url' => route('people.show', $user),
+                ],
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  array<string, array{handle: string, name: string, url: string}>  $resolved
+     * @return list<array{handle: string, name: string, url: string}>
+     */
+    public function forBody(string $body, array $resolved): array
+    {
+        $mentions = [];
+
+        foreach ($this->parser->handles($body) as $handle) {
+            if (isset($resolved[$handle])) {
+                $mentions[] = $resolved[$handle];
+            }
+        }
+
+        return $mentions;
+    }
+}

--- a/app/Community/NotificationCenter.php
+++ b/app/Community/NotificationCenter.php
@@ -5,6 +5,7 @@ namespace App\Community;
 use App\Enums\NotificationType;
 use App\Models\Comment;
 use App\Models\CommentReport;
+use App\Models\Post;
 use App\Models\PostReport;
 use App\Models\Space;
 use App\Models\User;
@@ -114,9 +115,97 @@ final class NotificationCenter
     {
         return match (NotificationType::tryFrom($notification->type)) {
             NotificationType::CommentReply => $this->resolveCommentReply($viewer, $notification),
+            NotificationType::ContentMention => $this->resolveContentMention($viewer, $notification),
             NotificationType::SpaceModeration => $this->resolveSpaceModeration($viewer, $notification),
             default => $this->unavailable(),
         };
+    }
+
+    /** @return array{kind: string, title: string, description: string, destination: string|null} */
+    private function resolveContentMention(User $viewer, DatabaseNotification $notification): array
+    {
+        $contentId = $this->integer($notification, 'content_id');
+        $postId = $this->integer($notification, 'post_id');
+        $actorId = $this->integer($notification, 'actor_id');
+        $contentType = $notification->data['content_type'] ?? null;
+
+        if ($contentId === null
+            || $postId === null
+            || $actorId === null
+            || ! in_array($contentType, ['post', 'comment'], true)) {
+            return $this->unavailable();
+        }
+
+        if ($contentType === 'post') {
+            $post = Post::query()
+                ->with(['author', 'space'])
+                ->whereKey($contentId)
+                ->whereKey($postId)
+                ->where('user_id', $actorId)
+                ->first();
+
+            if (! $post instanceof Post
+                || Gate::forUser($viewer)->denies('view', $post)) {
+                return $this->unavailable();
+            }
+
+            return $this->resolvedMention(
+                $viewer,
+                $post->author,
+                'post',
+                'Open the post in '.$post->space->name.'.',
+                route('posts.show', $post),
+            );
+        }
+
+        $comment = Comment::query()
+            ->with(['author', 'post.author', 'post.space'])
+            ->whereKey($contentId)
+            ->where('post_id', $postId)
+            ->where('user_id', $actorId)
+            ->first();
+
+        if (! $comment instanceof Comment
+            || Gate::forUser($viewer)->denies('view', $comment)) {
+            return $this->unavailable();
+        }
+
+        $destination = $this->conversations->urlForComment($viewer, $comment);
+
+        if ($destination === null) {
+            return $this->unavailable();
+        }
+
+        return $this->resolvedMention(
+            $viewer,
+            $comment->author,
+            'comment',
+            'Open the conversation in '.$comment->post->space->name.'.',
+            $destination,
+        );
+    }
+
+    /** @return array{kind: string, title: string, description: string, destination: string} */
+    private function resolvedMention(
+        User $viewer,
+        User $actor,
+        string $contentType,
+        string $description,
+        string $destination,
+    ): array {
+        $actorVisible = User::query()
+            ->visibleTo($viewer)
+            ->whereKey($actor->getKey())
+            ->exists();
+
+        return [
+            'kind' => NotificationType::ContentMention->value,
+            'title' => $actorVisible
+                ? $actor->name.' mentioned you in a '.$contentType
+                : 'A member mentioned you in a '.$contentType,
+            'description' => $description,
+            'destination' => $destination,
+        ];
     }
 
     /** @return array{kind: string, title: string, description: string, destination: string|null} */
@@ -213,6 +302,10 @@ final class NotificationCenter
     ): ?array {
         return match (NotificationType::tryFrom($notification->type)) {
             NotificationType::CommentReply => $this->notificationApiTargetForCommentReply($notification, $resolved),
+            NotificationType::ContentMention => $this->notificationApiTargetForContentMention(
+                $notification,
+                $resolved,
+            ),
             NotificationType::SpaceModeration => $this->notificationApiTargetForSpaceModeration(
                 $viewer,
                 $notification,
@@ -220,6 +313,35 @@ final class NotificationCenter
             ),
             default => null,
         };
+    }
+
+    /**
+     * @param  array{destination: string|null, kind: string, title: string, description: string}  $resolved
+     * @return array{type: string, post_id: string, comment_id?: string}|null
+     */
+    private function notificationApiTargetForContentMention(
+        DatabaseNotification $notification,
+        array $resolved,
+    ): ?array {
+        if ($resolved['destination'] === null) {
+            return null;
+        }
+
+        $postId = $this->integer($notification, 'post_id');
+        $contentId = $this->integer($notification, 'content_id');
+        $contentType = $notification->data['content_type'] ?? null;
+
+        if ($postId === null
+            || $contentId === null
+            || ! in_array($contentType, ['post', 'comment'], true)) {
+            return null;
+        }
+
+        return array_filter([
+            'type' => 'post',
+            'post_id' => (string) $postId,
+            'comment_id' => $contentType === 'comment' ? (string) $contentId : null,
+        ], fn (mixed $value): bool => $value !== null);
     }
 
     /**

--- a/app/Community/PostConversation.php
+++ b/app/Community/PostConversation.php
@@ -2,6 +2,7 @@
 
 namespace App\Community;
 
+use App\Community\Mentions\MentionProjection;
 use App\Enums\ReportStatus;
 use App\Enums\UserRelationshipType;
 use App\Models\Comment;
@@ -20,6 +21,7 @@ final class PostConversation
     public function __construct(
         private readonly PostMediaView $media,
         private readonly PostReactionProjection $reactions,
+        private readonly MentionProjection $mentions,
     ) {}
 
     /**
@@ -55,6 +57,10 @@ final class PostConversation
             ->withQueryString();
 
         $commentModels = $comments->getCollection();
+        $resolvedMentions = $this->mentions->resolve(
+            $viewer,
+            $commentModels->pluck('body')->push($post->body),
+        );
         $visibleAuthorIds = User::query()
             ->visibleTo($viewer)
             ->whereKey($commentModels->pluck('user_id')->push($post->user_id)->unique())
@@ -86,6 +92,7 @@ final class PostConversation
             $commentData[] = [
                 'id' => $comment->id,
                 'body' => $comment->body,
+                'mentions' => $this->mentions->forBody($comment->body, $resolvedMentions),
                 'publishedAt' => $comment->published_at->toIso8601String(),
                 'editedAt' => $comment->edited_at?->toIso8601String(),
                 'canReport' => $viewer->can('report', $comment),
@@ -107,6 +114,7 @@ final class PostConversation
                 'id' => $post->id,
                 'url' => route('posts.show', $post),
                 'body' => $post->body,
+                'mentions' => $this->mentions->forBody($post->body, $resolvedMentions),
                 'media' => $this->media->for($post),
                 'publishedAt' => $post->published_at?->toIso8601String(),
                 'editedAt' => $post->edited_at?->toIso8601String(),

--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -5,5 +5,6 @@ namespace App\Enums;
 enum NotificationType: string
 {
     case CommentReply = 'comment_reply';
+    case ContentMention = 'content_mention';
     case SpaceModeration = 'space_moderation';
 }

--- a/app/Http/Controllers/Api/V1/FeedController.php
+++ b/app/Http/Controllers/Api/V1/FeedController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Api\V1\FeedCursor;
+use App\Community\Mentions\MentionProjection;
 use App\Community\PostReactionProjection;
 use App\Community\VisiblePostQuery;
 use App\Http\Controllers\Controller;
@@ -26,6 +27,7 @@ class FeedController extends Controller
         VisiblePostQuery $visiblePosts,
         FeedCursor $cursors,
         PostReactionProjection $reactions,
+        MentionProjection $mentions,
     ): JsonResponse {
         /** @var User $viewer */
         $viewer = $request->user();
@@ -86,6 +88,7 @@ class FeedController extends Controller
         $posts = $posts->take($limit)->values();
 
         $this->addViewerState($posts, $viewer, $reactions);
+        $this->addMentionState($posts, $viewer, $mentions);
 
         $lastPost = $posts->last();
         $nextCursor = $hasMore && $lastPost instanceof Post
@@ -114,6 +117,20 @@ class FeedController extends Controller
                 'source' => $source,
             ],
         ]);
+    }
+
+    /** @param Collection<int, Post> $posts */
+    private function addMentionState(
+        Collection $posts,
+        User $viewer,
+        MentionProjection $mentions,
+    ): void {
+        $resolved = $mentions->resolve($viewer, $posts->pluck('body'));
+
+        $posts->each(fn (Post $post) => $post->setAttribute(
+            'content_mentions',
+            $mentions->forBody($post->body, $resolved),
+        ));
     }
 
     /** @param Collection<int, Post> $posts */

--- a/app/Http/Controllers/Api/V1/PostCommentController.php
+++ b/app/Http/Controllers/Api/V1/PostCommentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Api\V1\PostCommentCursor;
+use App\Community\Mentions\MentionProjection;
 use App\Community\VisiblePostQuery;
 use App\Enums\UserRelationshipType;
 use App\Http\Controllers\Controller;
@@ -24,6 +25,7 @@ class PostCommentController extends Controller
         string $post,
         VisiblePostQuery $visiblePosts,
         PostCommentCursor $cursorFactory,
+        MentionProjection $mentions,
     ): JsonResponse {
         /** @var User $viewer */
         $viewer = $request->user();
@@ -80,6 +82,11 @@ class PostCommentController extends Controller
             ->toArray();
 
         $this->addViewerState($comments, $viewer, $reportedCommentIds, $visibleAuthorIds);
+        $resolvedMentions = $mentions->resolve($viewer, $comments->pluck('body'));
+        $comments->each(fn (Comment $comment) => $comment->setAttribute(
+            'content_mentions',
+            $mentions->forBody($comment->body, $resolvedMentions),
+        ));
 
         $lastComment = $comments->last();
         $nextCursor = $hasMore && $lastComment instanceof Comment

--- a/app/Http/Controllers/Api/V1/PostController.php
+++ b/app/Http/Controllers/Api/V1/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Community\Mentions\MentionProjection;
 use App\Community\PostReactionProjection;
 use App\Community\VisiblePostQuery;
 use App\Http\Controllers\Controller;
@@ -21,6 +22,7 @@ class PostController extends Controller
         string $post,
         VisiblePostQuery $visiblePosts,
         PostReactionProjection $reactions,
+        MentionProjection $mentions,
     ): JsonResponse {
         /** @var User $viewer */
         $viewer = $request->user();
@@ -30,6 +32,11 @@ class PostController extends Controller
             ->firstOrFail();
 
         $this->addViewerState(new Collection([$postModel]), $viewer, $reactions);
+        $resolvedMentions = $mentions->resolve($viewer, [$postModel->body]);
+        $postModel->setAttribute(
+            'content_mentions',
+            $mentions->forBody($postModel->body, $resolvedMentions),
+        );
 
         return response()->json([
             'data' => (new PostResource($postModel))->toArray($request),

--- a/app/Http/Controllers/PeopleController.php
+++ b/app/Http/Controllers/PeopleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Community\Mentions\MentionProjection;
 use App\Community\PostMediaView;
 use App\Enums\ReportStatus;
 use App\Models\Post;
@@ -50,8 +51,12 @@ class PeopleController extends Controller
         ]);
     }
 
-    public function show(Request $request, User $profile, PostMediaView $media): Response
-    {
+    public function show(
+        Request $request,
+        User $profile,
+        PostMediaView $media,
+        MentionProjection $mentions,
+    ): Response {
         Gate::authorize('view', $profile);
 
         /** @var User $viewer */
@@ -104,12 +109,14 @@ class PeopleController extends Controller
             ])
             ->pluck('post_id')
             ->all();
+        $resolvedMentions = $mentions->resolve($viewer, $postModels->pluck('body'));
 
         $posts = $postModels
             ->map(fn (Post $post): array => [
                 'id' => $post->id,
                 'url' => route('posts.show', $post),
                 'body' => $post->body,
+                'mentions' => $mentions->forBody($post->body, $resolvedMentions),
                 'media' => $media->for($post),
                 'publishedAt' => $post->published_at?->toIso8601String(),
                 'editedAt' => $post->edited_at?->toIso8601String(),

--- a/app/Http/Controllers/Settings/NotificationPreferencesController.php
+++ b/app/Http/Controllers/Settings/NotificationPreferencesController.php
@@ -18,6 +18,7 @@ class NotificationPreferencesController extends Controller
         return Inertia::render('settings/notifications', [
             'preferences' => [
                 'commentReplies' => $preferences->exists ? $preferences->comment_replies : true,
+                'contentMentions' => $preferences->exists ? $preferences->content_mentions : true,
                 'spaceModeration' => $preferences->exists ? $preferences->space_moderation : true,
             ],
         ]);

--- a/app/Http/Requests/UpdateNotificationPreferencesRequest.php
+++ b/app/Http/Requests/UpdateNotificationPreferencesRequest.php
@@ -11,6 +11,7 @@ class UpdateNotificationPreferencesRequest extends FormRequest
     {
         return [
             'comment_replies' => ['required', 'boolean'],
+            'content_mentions' => ['required', 'boolean'],
             'space_moderation' => ['required', 'boolean'],
         ];
     }

--- a/app/Http/Resources/Api/V1/CommentResource.php
+++ b/app/Http/Resources/Api/V1/CommentResource.php
@@ -18,6 +18,7 @@ class CommentResource extends JsonResource
         return [
             'id' => (string) $comment->getKey(),
             'body' => $comment->body,
+            'mentions' => $comment->getAttribute('content_mentions') ?? [],
             'published_at' => $comment->published_at->toIso8601String(),
             'edited_at' => $comment->edited_at?->toIso8601String(),
             'author' => [

--- a/app/Http/Resources/Api/V1/PostResource.php
+++ b/app/Http/Resources/Api/V1/PostResource.php
@@ -27,6 +27,7 @@ class PostResource extends JsonResource
         return [
             'id' => (string) $post->getKey(),
             'body' => $post->body,
+            'mentions' => $post->getAttribute('content_mentions') ?? [],
             'published_at' => $post->published_at?->toIso8601String(),
             'edited_at' => $post->edited_at?->toIso8601String(),
             'media' => $media instanceof PostMedia ? [

--- a/app/Listeners/NotifyUsersMentionedInComment.php
+++ b/app/Listeners/NotifyUsersMentionedInComment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Community\Mentions\MentionNotifier;
+use App\Events\CommentPublished;
+
+class NotifyUsersMentionedInComment
+{
+    public function __construct(private readonly MentionNotifier $mentions) {}
+
+    public function handle(CommentPublished $event): void
+    {
+        $this->mentions->forComment($event->comment);
+    }
+}

--- a/app/Listeners/NotifyUsersMentionedInPost.php
+++ b/app/Listeners/NotifyUsersMentionedInPost.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Community\Mentions\MentionNotifier;
+use App\Events\PostPublished;
+
+class NotifyUsersMentionedInPost
+{
+    public function __construct(private readonly MentionNotifier $mentions) {}
+
+    public function handle(PostPublished $event): void
+    {
+        $this->mentions->forPost($event->post);
+    }
+}

--- a/app/Models/NotificationPreference.php
+++ b/app/Models/NotificationPreference.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * @property int $user_id
  * @property bool $comment_replies
+ * @property bool $content_mentions
  * @property bool $space_moderation
  * @property-read User $user
  */
@@ -15,6 +16,7 @@ class NotificationPreference extends Model
 {
     protected $fillable = [
         'comment_replies',
+        'content_mentions',
         'space_moderation',
     ];
 
@@ -23,6 +25,7 @@ class NotificationPreference extends Model
     {
         return [
             'comment_replies' => 'boolean',
+            'content_mentions' => 'boolean',
             'space_moderation' => 'boolean',
         ];
     }

--- a/app/Notifications/ContentMentionNotification.php
+++ b/app/Notifications/ContentMentionNotification.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\NotificationType;
+use App\Models\Comment;
+use App\Models\Post;
+use Illuminate\Notifications\Notification;
+
+class ContentMentionNotification extends Notification
+{
+    private function __construct(
+        private readonly string $contentType,
+        private readonly int $contentId,
+        private readonly int $postId,
+        private readonly int $actorId,
+    ) {}
+
+    public static function forPost(Post $post): self
+    {
+        return new self(
+            'post',
+            $post->getKey(),
+            $post->getKey(),
+            $post->user_id,
+        );
+    }
+
+    public static function forComment(Comment $comment): self
+    {
+        return new self(
+            'comment',
+            $comment->getKey(),
+            $comment->post_id,
+            $comment->user_id,
+        );
+    }
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function databaseType(object $notifiable): string
+    {
+        return NotificationType::ContentMention->value;
+    }
+
+    /** @return array{actor_id: int, content_id: int, content_type: string, post_id: int} */
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'actor_id' => $this->actorId,
+            'content_id' => $this->contentId,
+            'content_type' => $this->contentType,
+            'post_id' => $this->postId,
+        ];
+    }
+}

--- a/database/migrations/2026_07_24_000002_add_content_mentions_to_notification_preferences.php
+++ b/database/migrations/2026_07_24_000002_add_content_mentions_to_notification_preferences.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('notification_preferences', function (Blueprint $table): void {
+            $table->boolean('content_mentions')
+                ->default(true)
+                ->after('comment_replies');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('notification_preferences', function (Blueprint $table): void {
+            $table->dropColumn('content_mentions');
+        });
+    }
+};

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -201,6 +201,8 @@ The first resources expose only allowlisted fields:
 - posts and comments exclude storage paths, report details, moderator notes,
   hidden timestamps, and author account identifiers; nullable `edited_at`
   communicates an author change without exposing internal update timestamps;
+  each `mentions` array contains at most ten profile summaries that the current
+  viewer may open, while inaccessible or unknown handles remain plain body text;
   post reactions expose bounded counts and only the current viewer's selected
   type, never reactor identities;
 - media exposes only the authorized API URL, alt text, normalized dimensions,

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,19 +1,26 @@
 # In-app notifications
 
-The first notification slice is intentionally small and useful. It alerts a
-member when another member replies to their post and alerts eligible Space owners
-or moderators when a new post or comment report needs attention.
+The notification core is intentionally small and useful. It alerts a member
+when another member replies to their post or directly mentions their handle,
+and alerts eligible Space owners or moderators when a new post or comment
+report needs attention.
 
 ## Categories and delivery
 
 | Preference | Trigger | Recipient |
 | --- | --- | --- |
 | `comment_replies` | `CommentPublished` | The post author, unless they wrote the reply |
+| `content_mentions` | `PostPublished`, `CommentPublished`, or an author edit | Up to ten visible mentioned members, excluding the author |
 | `space_moderation` | `PostReported` or `CommentReported` | Current Space owners and moderators, excluding the reporter |
 
-Both preferences default to enabled and affect new notifications only. Delivery
-uses Laravel's database channel synchronously, so the core experience does not
-require a queue worker. Email, web push, mobile push, digests, mentions, and
+All preferences default to enabled and affect new notifications only. Mention
+handles are case-insensitive, deduplicated, and bounded to ten per body. Editing
+content alerts only newly added handles. A mentioned post author receives the
+ordinary reply notification instead of a second alert unless reply alerts are
+disabled.
+
+Delivery uses Laravel's database channel synchronously, so the core experience
+does not require a queue worker. Email, web push, mobile push, digests, and
 per-reaction notifications are not part of this release. Typed post reactions
 emit `PostReactionChanged` for extensions, but the core deliberately avoids a
 notification for every reaction.
@@ -22,10 +29,11 @@ does not create a notification for every follow in this release.
 
 ## Privacy and authorization
 
-Notification rows store stable identifiers, not post or comment excerpts, report
-details, or reporter identity. The presentation layer resolves those identifiers
-at request time and rechecks the same policies, profile visibility, Space access,
-mute relationships, and block relationships used by the destination itself.
+Notification rows store stable identifiers, not post or comment excerpts,
+report details, or reporter identity. Mention links are also resolved for the
+current viewer instead of being stored in rendered content. The presentation
+layer rechecks the same policies, profile visibility, Space access, mute
+relationships, and block relationships used by the destination itself.
 
 Opening a notification is a `POST` action. The server confirms that the
 notification belongs to the authenticated member, resolves its current safe

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1119,12 +1119,36 @@
           }
         }
       },
+      "ContentMention": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "handle",
+          "name",
+          "url"
+        ],
+        "properties": {
+          "handle": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 40
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri-reference"
+          }
+        }
+      },
       "Comment": {
         "type": "object",
         "additionalProperties": false,
         "required": [
           "id",
           "body",
+          "mentions",
           "published_at",
           "edited_at",
           "author",
@@ -1137,6 +1161,13 @@
           "body": {
             "type": "string",
             "maxLength": 1000
+          },
+          "mentions": {
+            "type": "array",
+            "maxItems": 10,
+            "items": {
+              "$ref": "#/components/schemas/ContentMention"
+            }
           },
           "published_at": {
             "type": "string",
@@ -1176,6 +1207,7 @@
         "required": [
           "id",
           "body",
+          "mentions",
           "published_at",
           "edited_at",
           "media",
@@ -1192,6 +1224,13 @@
           "body": {
             "type": "string",
             "maxLength": 2000
+          },
+          "mentions": {
+            "type": "array",
+            "maxItems": 10,
+            "items": {
+              "$ref": "#/components/schemas/ContentMention"
+            }
           },
           "published_at": {
             "type": "string",
@@ -1404,6 +1443,7 @@
             "type": "string",
             "enum": [
               "comment_reply",
+              "content_mention",
               "space_moderation",
               "unavailable"
             ]

--- a/resources/js/components/social/comment-thread.tsx
+++ b/resources/js/components/social/comment-thread.tsx
@@ -5,11 +5,14 @@ import type { FormEvent } from 'react';
 import InputError from '@/components/input-error';
 import { AuthoredContentMenu } from '@/components/social/authored-content-menu';
 import { AvatarMark } from '@/components/social/avatar-mark';
+import { MentionText } from '@/components/social/mention-text';
+import type { ContentMention } from '@/components/social/mention-text';
 import { Button } from '@/components/ui/button';
 
 export type SocialComment = {
     id: number;
     body: string;
+    mentions: ContentMention[];
     publishedAt: string;
     editedAt: string | null;
     canReport: boolean;
@@ -191,7 +194,10 @@ export function CommentRow({
                         />
                     </div>
                     <p className="mt-1 text-sm leading-6 whitespace-pre-wrap text-foreground/90">
-                        {previewBody}
+                        <MentionText
+                            body={previewBody}
+                            mentions={comment.mentions}
+                        />
                     </p>
                     {hasLongBody && (
                         <button

--- a/resources/js/components/social/mention-text.tsx
+++ b/resources/js/components/social/mention-text.tsx
@@ -1,0 +1,57 @@
+import { Link } from '@inertiajs/react';
+import type { ReactNode } from 'react';
+
+export type ContentMention = {
+    handle: string;
+    name: string;
+    url: string;
+};
+
+type MentionTextProps = {
+    body: string;
+    mentions: ContentMention[];
+};
+
+const mentionPattern = /@([a-z0-9]+(?:-[a-z0-9]+)*)\b/gi;
+const invalidPrefixPattern = /[a-z0-9._/@-]/i;
+
+export function MentionText({ body, mentions }: MentionTextProps) {
+    const profiles = new Map(
+        mentions.map((mention) => [mention.handle, mention]),
+    );
+    const content: ReactNode[] = [];
+    let cursor = 0;
+
+    for (const match of body.matchAll(mentionPattern)) {
+        const index = match.index;
+        const handle = match[1]?.toLowerCase();
+        const prefix = index > 0 ? body[index - 1] : '';
+        const mention = handle ? profiles.get(handle) : undefined;
+
+        if (!mention || invalidPrefixPattern.test(prefix)) {
+            continue;
+        }
+
+        if (index > cursor) {
+            content.push(body.slice(cursor, index));
+        }
+
+        content.push(
+            <Link
+                key={`${index}-${handle}`}
+                href={mention.url}
+                title={mention.name}
+                className="social-focus rounded-sm font-bold text-primary hover:underline"
+            >
+                {match[0]}
+            </Link>,
+        );
+        cursor = index + match[0].length;
+    }
+
+    if (cursor < body.length) {
+        content.push(body.slice(cursor));
+    }
+
+    return <>{content}</>;
+}

--- a/resources/js/pages/feed/index.tsx
+++ b/resources/js/pages/feed/index.tsx
@@ -22,6 +22,8 @@ import { AvatarMark } from '@/components/social/avatar-mark';
 import { CommentThread } from '@/components/social/comment-thread';
 import type { SocialComment } from '@/components/social/comment-thread';
 import { CommunitySignal } from '@/components/social/community-signal';
+import { MentionText } from '@/components/social/mention-text';
+import type { ContentMention } from '@/components/social/mention-text';
 import { PostImage } from '@/components/social/post-image';
 import type { PostMedia } from '@/components/social/post-image';
 import { PostReactions } from '@/components/social/post-reactions';
@@ -49,6 +51,7 @@ type FeedPost = {
     id: number;
     url: string;
     body: string;
+    mentions: ContentMention[];
     media: PostMedia | null;
     publishedAt: string | null;
     editedAt: string | null;
@@ -548,7 +551,7 @@ function PostCard({
                 </div>
             </header>
             <p className="mt-4 text-[1.01rem] leading-7 whitespace-pre-wrap text-foreground/92 sm:text-[1.04rem] sm:leading-8">
-                {previewBody}
+                <MentionText body={previewBody} mentions={item.mentions} />
             </p>
             {hasLongBody && (
                 <button

--- a/resources/js/pages/notifications/index.tsx
+++ b/resources/js/pages/notifications/index.tsx
@@ -1,5 +1,6 @@
 import { Head, Link, router } from '@inertiajs/react';
 import {
+    AtSign,
     BellOff,
     BellRing,
     Check,
@@ -15,7 +16,11 @@ import { cn } from '@/lib/utils';
 
 type NotificationItem = {
     id: string;
-    kind: 'comment_reply' | 'space_moderation' | 'unavailable';
+    kind:
+        | 'comment_reply'
+        | 'content_mention'
+        | 'space_moderation'
+        | 'unavailable';
     title: string;
     description: string;
     createdAt: string;
@@ -71,8 +76,9 @@ export default function Notifications({
                                 Notifications
                             </h1>
                             <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
-                                Replies and moderation work that deserve your
-                                attention — no engagement ranking or noise.
+                                Replies, mentions, and moderation work that
+                                deserve your attention — no engagement ranking
+                                or noise.
                             </p>
                         </div>
                         <Button
@@ -146,8 +152,9 @@ export default function Notifications({
                                         : 'Nothing here yet.'}
                                 </h3>
                                 <p className="mx-auto mt-1 max-w-sm text-sm leading-6 text-muted-foreground">
-                                    Useful replies and moderation alerts will
-                                    appear here when they happen.
+                                    Useful replies, direct mentions, and
+                                    moderation alerts will appear here when they
+                                    happen.
                                 </p>
                             </div>
                         ) : (
@@ -195,9 +202,9 @@ export default function Notifications({
                                 Low-noise by design
                             </p>
                             <p className="mt-3 text-sm leading-6 text-muted-foreground">
-                                This inbox contains direct replies and
-                                moderation work. Likes, popularity scores, and
-                                algorithmic nudges are intentionally absent.
+                                This inbox contains direct replies, mentions,
+                                and moderation work. Likes, popularity scores,
+                                and algorithmic nudges are intentionally absent.
                             </p>
                         </div>
                         <Button
@@ -250,9 +257,11 @@ function NotificationRow({ item }: { item: NotificationItem }) {
     const Icon =
         item.kind === 'comment_reply'
             ? MessageCircle
-            : item.kind === 'space_moderation'
-              ? Flag
-              : BellOff;
+            : item.kind === 'content_mention'
+              ? AtSign
+              : item.kind === 'space_moderation'
+                ? Flag
+                : BellOff;
 
     return (
         <li
@@ -273,9 +282,11 @@ function NotificationRow({ item }: { item: NotificationItem }) {
                         'flex size-11 shrink-0 items-center justify-center rounded-2xl',
                         item.kind === 'comment_reply'
                             ? 'bg-primary/10 text-primary'
-                            : item.kind === 'space_moderation'
-                              ? 'bg-coral/12 text-coral'
-                              : 'bg-secondary text-muted-foreground',
+                            : item.kind === 'content_mention'
+                              ? 'bg-mint/16 text-foreground'
+                              : item.kind === 'space_moderation'
+                                ? 'bg-coral/12 text-coral'
+                                : 'bg-secondary text-muted-foreground',
                     )}
                 >
                     <Icon className="size-5" aria-hidden="true" />

--- a/resources/js/pages/people/show.tsx
+++ b/resources/js/pages/people/show.tsx
@@ -11,6 +11,8 @@ import {
 } from 'lucide-react';
 import { AuthoredContentMenu } from '@/components/social/authored-content-menu';
 import { AvatarMark } from '@/components/social/avatar-mark';
+import { MentionText } from '@/components/social/mention-text';
+import type { ContentMention } from '@/components/social/mention-text';
 import { PostImage } from '@/components/social/post-image';
 import type { PostMedia } from '@/components/social/post-image';
 import { SpaceCover } from '@/components/social/space-cover';
@@ -51,6 +53,7 @@ type ProfilePost = {
     id: number;
     url: string;
     body: string;
+    mentions: ContentMention[];
     media: PostMedia | null;
     publishedAt: string | null;
     editedAt: string | null;
@@ -502,7 +505,10 @@ export default function ShowProfile({
                                             />
                                         </header>
                                         <p className="mt-4 text-[1.01rem] leading-7 whitespace-pre-wrap text-foreground/90">
-                                            {post.body}
+                                            <MentionText
+                                                body={post.body}
+                                                mentions={post.mentions}
+                                            />
                                         </p>
                                         {post.media && (
                                             <PostImage

--- a/resources/js/pages/posts/show.tsx
+++ b/resources/js/pages/posts/show.tsx
@@ -24,6 +24,8 @@ import type {
     SocialComment,
 } from '@/components/social/comment-thread';
 import { CommunitySignal } from '@/components/social/community-signal';
+import { MentionText } from '@/components/social/mention-text';
+import type { ContentMention } from '@/components/social/mention-text';
 import { PostImage } from '@/components/social/post-image';
 import type { PostMedia } from '@/components/social/post-image';
 import { PostReactions } from '@/components/social/post-reactions';
@@ -39,6 +41,7 @@ type ConversationPost = {
     id: number;
     url: string;
     body: string;
+    mentions: ContentMention[];
     media: PostMedia | null;
     publishedAt: string | null;
     editedAt: string | null;
@@ -353,7 +356,10 @@ export default function ShowPost({
                                 </header>
 
                                 <p className="mt-5 text-[1.04rem] leading-8 whitespace-pre-wrap text-foreground/92">
-                                    {post.body}
+                                    <MentionText
+                                        body={post.body}
+                                        mentions={post.mentions}
+                                    />
                                 </p>
 
                                 {post.media && (

--- a/resources/js/pages/settings/notifications.tsx
+++ b/resources/js/pages/settings/notifications.tsx
@@ -1,5 +1,5 @@
 import { Head, useForm } from '@inertiajs/react';
-import { BellRing, Flag, MessageCircle } from 'lucide-react';
+import { AtSign, BellRing, Flag, MessageCircle } from 'lucide-react';
 import type { FormEvent } from 'react';
 import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
@@ -8,6 +8,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 type NotificationPreferencesProps = {
     preferences: {
         commentReplies: boolean;
+        contentMentions: boolean;
         spaceModeration: boolean;
     };
     status?: string;
@@ -20,6 +21,7 @@ export default function NotificationPreferences({
     const { data, setData, patch, processing, isDirty, recentlySuccessful } =
         useForm({
             comment_replies: preferences.commentReplies,
+            content_mentions: preferences.contentMentions,
             space_moderation: preferences.spaceModeration,
         });
 
@@ -56,6 +58,15 @@ export default function NotificationPreferences({
                             checked={data.comment_replies}
                             onCheckedChange={(checked) =>
                                 setData('comment_replies', checked)
+                            }
+                        />
+                        <PreferenceRow
+                            icon={AtSign}
+                            title="Mentions in posts and comments"
+                            description="Know when another member directly mentions your handle. Repeated mentions in the same content create only one alert."
+                            checked={data.content_mentions}
+                            onCheckedChange={(checked) =>
+                                setData('content_mentions', checked)
                             }
                         />
                         <PreferenceRow

--- a/tests/Feature/Api/FeedTest.php
+++ b/tests/Feature/Api/FeedTest.php
@@ -30,7 +30,7 @@ class FeedTest extends TestCase
 
     public function test_feed_returns_only_policy_visible_posts_in_the_safe_public_contract(): void
     {
-        $viewer = User::factory()->create();
+        $viewer = User::factory()->create(['handle' => 'api-viewer']);
         $publicAuthor = User::factory()->create([
             'headline' => 'Public-space author',
             'profile_visibility' => ProfileVisibility::Private,
@@ -53,7 +53,7 @@ class FeedTest extends TestCase
             'published_at' => now()->subMinutes(2),
         ]);
         $newerPrivate = Post::factory()->for($private)->for($privateAuthor, 'author')->create([
-            'body' => 'Newer private-member post',
+            'body' => 'Newer private-member post for @api-viewer',
             'published_at' => now()->subMinute(),
         ]);
 
@@ -105,6 +105,8 @@ class FeedTest extends TestCase
             ->assertJsonPath('meta.has_more', false)
             ->assertJsonPath('links.next', null)
             ->assertJsonPath('data.0.id', (string) $newerPrivate->getKey())
+            ->assertJsonPath('data.0.mentions.0.handle', 'api-viewer')
+            ->assertJsonPath('data.0.mentions.0.url', route('people.show', $viewer))
             ->assertJsonPath('data.0.viewer.can_comment', true)
             ->assertJsonPath('data.0.author.profile_visible', true)
             ->assertJsonPath('data.0.space.slug', $private->slug)
@@ -130,7 +132,7 @@ class FeedTest extends TestCase
             ->assertHeader('X-RateLimit-Limit', '120');
 
         $this->assertSame(
-            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
+            ['id', 'body', 'mentions', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
             array_keys($response->json('data.0')),
         );
         $this->assertSame(

--- a/tests/Feature/Api/NotificationApiTest.php
+++ b/tests/Feature/Api/NotificationApiTest.php
@@ -8,6 +8,7 @@ use App\Models\PostReport;
 use App\Models\Space;
 use App\Models\User;
 use App\Notifications\CommentReplyNotification;
+use App\Notifications\ContentMentionNotification;
 use App\Notifications\SpaceModerationNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\DatabaseNotification;
@@ -106,6 +107,35 @@ class NotificationApiTest extends TestCase
             ->getJson(route('api.v1.notifications', ['cursor' => $cursor, 'filter' => 'unread']))
             ->assertBadRequest()
             ->assertJsonPath('code', 'invalid_cursor');
+    }
+
+    public function test_content_mentions_expose_only_a_current_policy_safe_target(): void
+    {
+        $viewer = User::factory()->create();
+        $author = User::factory()->create();
+        $space = Space::factory()->for($author, 'owner')->create();
+        $space->addMember($viewer);
+        $post = Post::factory()->for($space)->for($author, 'author')->create();
+        $viewer->notify(ContentMentionNotification::forPost($post));
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.notifications'))
+            ->assertOk()
+            ->assertJsonPath('data.0.kind', 'content_mention')
+            ->assertJsonPath('data.0.target.type', 'post')
+            ->assertJsonPath('data.0.target.post_id', (string) $post->getKey())
+            ->assertJsonMissingPath('data.0.target.comment_id');
+
+        $author->outgoingRelationships()->create([
+            'target_id' => $viewer->id,
+            'type' => 'block',
+        ]);
+
+        $this->withToken($this->token($viewer))
+            ->getJson(route('api.v1.notifications'))
+            ->assertOk()
+            ->assertJsonPath('data.0.kind', 'unavailable')
+            ->assertJsonPath('data.0.target', null);
     }
 
     public function test_notifications_write_endpoints_mark_one_and_all_read(): void

--- a/tests/Feature/Api/PostApiTest.php
+++ b/tests/Feature/Api/PostApiTest.php
@@ -22,7 +22,7 @@ class PostApiTest extends TestCase
 
     public function test_post_detail_returns_the_safe_visible_projection_and_viewer_state(): void
     {
-        $viewer = User::factory()->create();
+        $viewer = User::factory()->create(['handle' => 'api-viewer']);
         $author = User::factory()->create([
             'name' => 'Post Author',
             'headline' => 'Platform architect',
@@ -31,7 +31,7 @@ class PostApiTest extends TestCase
         $space = Space::factory()->for($author, 'owner')->create();
         $space->addMember($viewer);
         $post = Post::factory()->for($space)->for($author, 'author')->create([
-            'body' => 'A stable post for API readers.',
+            'body' => 'A stable post for @api-viewer.',
         ]);
 
         Storage::fake('media');
@@ -81,7 +81,9 @@ class PostApiTest extends TestCase
         $response
             ->assertOk()
             ->assertJsonPath('data.id', (string) $post->getKey())
-            ->assertJsonPath('data.body', 'A stable post for API readers.')
+            ->assertJsonPath('data.body', 'A stable post for @api-viewer.')
+            ->assertJsonPath('data.mentions.0.handle', 'api-viewer')
+            ->assertJsonPath('data.mentions.0.url', route('people.show', $viewer))
             ->assertJsonPath('data.comments_count', 1)
             ->assertJsonPath('data.reactions.total', 1)
             ->assertJsonPath('data.reactions.counts.celebrate', 1)
@@ -101,7 +103,7 @@ class PostApiTest extends TestCase
             ->assertJsonMissingPath('data.media.author_id');
 
         $this->assertSame(
-            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
+            ['id', 'body', 'mentions', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
             array_keys($response->json('data')),
         );
         $this->assertSame(
@@ -157,7 +159,7 @@ class PostApiTest extends TestCase
 
     public function test_post_comments_are_visible_in_chronological_pages_and_filter_muted_blocked_hidden_comments(): void
     {
-        $viewer = User::factory()->create();
+        $viewer = User::factory()->create(['handle' => 'api-viewer']);
         $author = User::factory()->create();
         $mutedAuthor = User::factory()->create();
         $blockingAuthor = User::factory()->create();
@@ -166,7 +168,7 @@ class PostApiTest extends TestCase
         $post = Post::factory()->for($space)->for($author, 'author')->create();
 
         Comment::factory()->for($post)->for($author, 'author')->create([
-            'body' => 'Visible 1',
+            'body' => 'Visible 1 @api-viewer',
             'published_at' => now()->subMinutes(3),
         ]);
         $reported = Comment::factory()->for($post)->for($author, 'author')->create([
@@ -218,6 +220,8 @@ class PostApiTest extends TestCase
             ->assertJsonPath('links.next', fn (?string $url): bool => is_string($url) && str_contains($url, 'cursor='))
             ->assertJsonCount(2, 'data')
             ->assertJsonPath('data.0.id', (string) $post->comments()->orderBy('published_at')->first()->getKey())
+            ->assertJsonPath('data.0.mentions.0.handle', 'api-viewer')
+            ->assertJsonPath('data.0.mentions.0.url', route('people.show', $viewer))
             ->assertJsonPath('data.1.id', (string) $reported->getKey())
             ->assertJsonPath('data.1.viewer.can_report', true)
             ->assertJsonPath('data.1.viewer.has_reported', true)

--- a/tests/Feature/ContentMentionTest.php
+++ b/tests/Feature/ContentMentionTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class ContentMentionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_post_mention_creates_one_low_data_notification_and_visible_link(): void
+    {
+        $author = User::factory()->create(['name' => 'Andrew', 'handle' => 'andrew']);
+        $mentioned = User::factory()->create(['name' => 'Maya Chen', 'handle' => 'maya-chen']);
+        $space = Space::factory()->for($author, 'owner')->create(['name' => 'Makers Circle']);
+        $space->addMember($mentioned);
+
+        $this->actingAs($author)
+            ->post(route('spaces.posts.store', $space), [
+                'body' => 'Welcome @maya-chen — thank you again @maya-chen.',
+            ])
+            ->assertRedirect();
+
+        $post = Post::query()->sole();
+        $notification = DatabaseNotification::query()
+            ->where('notifiable_id', $mentioned->id)
+            ->sole();
+
+        $this->assertSame('content_mention', $notification->type);
+        $this->assertSame(
+            ['actor_id', 'content_id', 'content_type', 'post_id'],
+            array_keys(collect($notification->data)->sortKeys()->all()),
+        );
+        $this->assertStringNotContainsString(
+            'Welcome',
+            json_encode($notification->data, JSON_THROW_ON_ERROR),
+        );
+
+        $this->actingAs($mentioned)
+            ->get(route('feed'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('posts.0.id', $post->id)
+                ->has('posts.0.mentions', 1)
+                ->where('posts.0.mentions.0.handle', 'maya-chen')
+                ->where('posts.0.mentions.0.url', route('people.show', $mentioned)));
+
+        $this->actingAs($mentioned)
+            ->get(route('notifications.index'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('items.0.kind', 'content_mention')
+                ->where('items.0.title', 'Andrew mentioned you in a post')
+                ->where('items.0.description', 'Open the post in Makers Circle.')
+                ->where('items.0.available', true));
+    }
+
+    public function test_comment_mentions_respect_self_block_mute_and_notification_preferences(): void
+    {
+        $author = User::factory()->create(['handle' => 'author']);
+        $mentioned = User::factory()->create(['handle' => 'mentioned']);
+        $muted = User::factory()->create(['handle' => 'muted']);
+        $blocked = User::factory()->create(['handle' => 'blocked']);
+        $quiet = User::factory()->create(['handle' => 'quiet']);
+        $space = Space::factory()->for($author, 'owner')->create();
+
+        foreach ([$mentioned, $muted, $blocked, $quiet] as $member) {
+            $space->addMember($member);
+        }
+
+        $post = Post::factory()->for($space)->for($mentioned, 'author')->create();
+        $muted->outgoingRelationships()->create([
+            'target_id' => $author->id,
+            'type' => 'mute',
+        ]);
+        $blocked->outgoingRelationships()->create([
+            'target_id' => $author->id,
+            'type' => 'block',
+        ]);
+        $quiet->notificationPreference()->create([
+            'content_mentions' => false,
+            'comment_replies' => true,
+            'space_moderation' => true,
+        ]);
+
+        $this->actingAs($author)
+            ->post(route('posts.comments.store', $post), [
+                'body' => '@author @mentioned @muted @blocked @quiet',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('notifications', [
+            'notifiable_id' => $mentioned->id,
+            'type' => 'comment_reply',
+        ]);
+        $this->assertDatabaseMissing('notifications', [
+            'notifiable_id' => $mentioned->id,
+            'type' => 'content_mention',
+        ]);
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $author->id]);
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $muted->id]);
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $blocked->id]);
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $quiet->id]);
+    }
+
+    public function test_editing_content_notifies_only_new_mentions_and_removes_stale_links(): void
+    {
+        $author = User::factory()->create(['handle' => 'author']);
+        $first = User::factory()->create(['handle' => 'first-member']);
+        $second = User::factory()->create(['handle' => 'second-member']);
+        $space = Space::factory()->for($author, 'owner')->create();
+        $space->addMember($first);
+        $space->addMember($second);
+        $post = Post::factory()->for($space)->for($author, 'author')->create([
+            'body' => 'Hello @first-member.',
+        ]);
+
+        $this->actingAs($author)
+            ->patch(route('posts.update', $post), [
+                'body' => 'Hello @second-member and @second-member.',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('notifications', ['notifiable_id' => $first->id]);
+        $this->assertDatabaseCount('notifications', 1);
+        $this->assertDatabaseHas('notifications', [
+            'notifiable_id' => $second->id,
+            'type' => 'content_mention',
+        ]);
+
+        $this->actingAs($author)
+            ->get(route('posts.show', $post))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('post.mentions', 1)
+                ->where('post.mentions.0.handle', 'second-member'));
+
+        $this->actingAs($author)
+            ->patch(route('posts.update', $post), [
+                'body' => 'Still here @second-member.',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseCount('notifications', 1);
+    }
+
+    public function test_a_mention_notification_becomes_unavailable_after_access_is_revoked(): void
+    {
+        $author = User::factory()->create(['handle' => 'author']);
+        $mentioned = User::factory()->create(['handle' => 'mentioned']);
+        $space = Space::factory()->for($author, 'owner')->create();
+        $space->addMember($mentioned);
+
+        $this->actingAs($author)
+            ->post(route('spaces.posts.store', $space), [
+                'body' => 'Hello @mentioned.',
+            ])
+            ->assertRedirect();
+
+        $notification = DatabaseNotification::query()->sole();
+        $author->outgoingRelationships()->create([
+            'target_id' => $mentioned->id,
+            'type' => 'block',
+        ]);
+
+        $this->actingAs($mentioned)
+            ->get(route('notifications.index'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('items.0.kind', 'unavailable')
+                ->where('items.0.available', false));
+
+        $this->actingAs($mentioned)
+            ->post(route('notifications.open', $notification->id))
+            ->assertRedirect(route('notifications.index'))
+            ->assertSessionHas('status', 'This notification is no longer available.');
+    }
+}

--- a/tests/Feature/Settings/NotificationPreferencesTest.php
+++ b/tests/Feature/Settings/NotificationPreferencesTest.php
@@ -21,11 +21,13 @@ class NotificationPreferencesTest extends TestCase
             ->assertInertia(fn (Assert $page) => $page
                 ->component('settings/notifications')
                 ->where('preferences.commentReplies', true)
+                ->where('preferences.contentMentions', true)
                 ->where('preferences.spaceModeration', true));
 
         $this->actingAs($user)
             ->patch(route('notification-preferences.update'), [
                 'comment_replies' => false,
+                'content_mentions' => false,
                 'space_moderation' => false,
             ])
             ->assertRedirect()
@@ -34,6 +36,7 @@ class NotificationPreferencesTest extends TestCase
         $this->assertDatabaseHas('notification_preferences', [
             'user_id' => $user->id,
             'comment_replies' => false,
+            'content_mentions' => false,
             'space_moderation' => false,
         ]);
     }
@@ -46,7 +49,7 @@ class NotificationPreferencesTest extends TestCase
             ->patch(route('notification-preferences.update'), [
                 'comment_replies' => 'sometimes',
             ])
-            ->assertSessionHasErrors(['comment_replies', 'space_moderation']);
+            ->assertSessionHasErrors(['comment_replies', 'content_mentions', 'space_moderation']);
 
         $this->assertDatabaseCount('notification_preferences', 0);
     }

--- a/tests/Unit/ApiContractDocumentationTest.php
+++ b/tests/Unit/ApiContractDocumentationTest.php
@@ -151,12 +151,16 @@ class ApiContractDocumentationTest extends TestCase
             array_keys($schemas['Space']['properties']),
         );
         $this->assertSame(
-            ['id', 'body', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
+            ['id', 'body', 'mentions', 'published_at', 'edited_at', 'media', 'comments_count', 'reactions', 'author', 'space', 'viewer'],
             array_keys($schemas['Post']['properties']),
         );
         $this->assertSame(
-            ['id', 'body', 'published_at', 'edited_at', 'author', 'viewer'],
+            ['id', 'body', 'mentions', 'published_at', 'edited_at', 'author', 'viewer'],
             array_keys($schemas['Comment']['properties']),
+        );
+        $this->assertSame(
+            ['handle', 'name', 'url'],
+            array_keys($schemas['ContentMention']['properties']),
         );
         $this->assertSame(
             ['handle', 'name', 'headline', 'profile_visible'],

--- a/tests/Unit/MentionParserTest.php
+++ b/tests/Unit/MentionParserTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Community\Mentions\MentionParser;
+use PHPUnit\Framework\TestCase;
+
+class MentionParserTest extends TestCase
+{
+    public function test_it_extracts_unique_normalized_handles_without_matching_emails_or_urls(): void
+    {
+        $parser = new MentionParser;
+
+        $this->assertSame(
+            ['andrew-matia', 'maker-42'],
+            $parser->handles(
+                'Thanks @Andrew-Matia, @maker-42 and again @andrew-matia. '
+                .'Ignore hello@example.com and https://example.com/@hidden-user.',
+            ),
+        );
+    }
+
+    public function test_it_bounds_the_number_of_mentions_in_one_body(): void
+    {
+        $parser = new MentionParser;
+        $body = collect(range(1, 25))
+            ->map(fn (int $index): string => '@member-'.$index)
+            ->implode(' ');
+
+        $this->assertCount(MentionParser::MAX_MENTIONS, $parser->handles($body));
+    }
+}


### PR DESCRIPTION
## Why

Communities need a simple way to bring the right member into a conversation without weakening profile or content privacy.

## What changed

- parse and deduplicate up to ten `@handle` mentions per post or comment
- resolve profile links for the current viewer instead of storing rendered links
- send low-data, edit-aware in-app alerts with a dedicated preference
- avoid duplicate reply and mention alerts for the same post author
- recheck content, profile, mute, block, and Space access whenever an alert is viewed or opened
- expose the same bounded projection through the read-only API and OpenAPI contract
- render accessible mention links across feed, permalink, comments, and profile activity

## Validation

- 191 PHPUnit tests / 2,104 assertions
- PHPStan, Pint, ESLint, Prettier, and TypeScript checks
- production Vite build
- Composer and npm dependency audits: no known vulnerabilities
- desktop and 390 px browser QA for publishing, profile navigation, notification opening, preferences, and horizontal overflow