### PR TITLE
Add secure account data rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable project changes will be documented here.
 
 ### Added
 
+- Password-confirmed, rate-limited personal JSON exports with chunked complete
+  collections for account, community, authored content, interaction,
+  moderation, messaging, notification, and safe security metadata.
+- Transactional account deletion guards that require ownership transfer when
+  an owned Space contains another member or another person's community
+  activity, with actionable Profile settings links.
 - Privacy-safe `@handle` mentions for posts and comments, including bounded
   case-insensitive parsing, viewer-resolved links across web and API surfaces,
   deduplicated low-data notifications, per-member preferences, edit-aware

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
   activity summaries, and privacy-aware People discovery.
 - Public, shared-Space-only, and private profile visibility with discovery opt-out.
 - Private one-way muting, mutual blocking, feed filtering, and a dedicated Safety recovery screen.
+- Password-confirmed, rate-limited personal JSON exports that stream complete
+  member-authored collections without exposing secrets or other participants'
+  messages.
+- Self-service account deletion that protects active communities by requiring
+  ownership transfer before another member's Space activity can be removed.
 - An editorial, app-first responsive interface with dedicated desktop and
   mobile navigation, a public product homepage, and complete member profiles.
 - Server-side authorization, validation, and publishing rate limits.
@@ -149,8 +154,8 @@ The current release is `0.1.0-alpha.1`. It is suitable for local evaluation and 
 
 This is an early development build, not a production release. Message
 attachments, galleries and video, email and push notification delivery,
-advanced indexed search, data export/deletion, and a supported extension
-lifecycle are still pending.
+advanced indexed search, administrator retention tooling, and a supported
+extension lifecycle are still pending.
 
 ## Local setup
 
@@ -213,6 +218,12 @@ learning—should build on those boundaries through presentation layers and
 extensions rather than weakening core policies. See
 [`docs/platform-architecture.md`](docs/platform-architecture.md) for the current
 separation and the contracts that still need to mature.
+
+Personal JSON export and account deletion are implemented as security-sensitive
+account flows, not as a compliance claim. See
+[`docs/privacy-and-data-rights.md`](docs/privacy-and-data-rights.md) for the
+included data, explicit secret and third-party exclusions, ownership-transfer
+guard, and deployment responsibilities.
 
 ## Contributing
 

--- a/app/Account/AccountDeletion.php
+++ b/app/Account/AccountDeletion.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Account;
+
+use App\Models\Space;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class AccountDeletion
+{
+    /**
+     * Owned Spaces that contain another person's membership or content.
+     *
+     * @return Collection<int, Space>
+     */
+    public function blockersFor(User $user): Collection
+    {
+        return $this->blockingSpacesQuery($user)
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug']);
+    }
+
+    public function delete(User $user): void
+    {
+        DB::transaction(function () use ($user): void {
+            $lockedUser = User::query()
+                ->whereKey($user->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            Space::query()
+                ->where('owner_id', $lockedUser->getKey())
+                ->lockForUpdate()
+                ->get(['id']);
+
+            $blockers = $this->blockersFor($lockedUser);
+
+            if ($blockers->isNotEmpty()) {
+                throw ValidationException::withMessages([
+                    'account' => 'Transfer ownership of Spaces with community activity before deleting your account.',
+                ]);
+            }
+
+            $lockedUser->delete();
+        }, 3);
+    }
+
+    /** @return Builder<Space> */
+    private function blockingSpacesQuery(User $user): Builder
+    {
+        return Space::query()
+            ->where('owner_id', $user->getKey())
+            ->where(function (Builder $spaces) use ($user): void {
+                $spaces
+                    ->whereHas('members', fn (Builder $members) => $members
+                        ->whereKeyNot($user->getKey()))
+                    ->orWhereHas('posts', fn (Builder $posts) => $posts
+                        ->where('user_id', '!=', $user->getKey()))
+                    ->orWhereHas('posts.comments', fn (Builder $comments) => $comments
+                        ->where('user_id', '!=', $user->getKey()))
+                    ->orWhereHas('invitations', fn (Builder $invitations) => $invitations
+                        ->where('invited_by', '!=', $user->getKey()))
+                    ->orWhereHas('auditLogs', fn (Builder $auditLogs) => $auditLogs
+                        ->where(function (Builder $people) use ($user): void {
+                            $people
+                                ->where('actor_id', '!=', $user->getKey())
+                                ->orWhere('subject_user_id', '!=', $user->getKey());
+                        }))
+                    ->orWhereHas('postReports', fn (Builder $reports) => $reports
+                        ->where('reporter_id', '!=', $user->getKey()))
+                    ->orWhereHas('commentReports', fn (Builder $reports) => $reports
+                        ->where('reporter_id', '!=', $user->getKey()));
+            });
+    }
+}

--- a/app/Http/Controllers/Settings/PersonalDataExportController.php
+++ b/app/Http/Controllers/Settings/PersonalDataExportController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Privacy\PersonalDataExport;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
+
+class PersonalDataExportController extends Controller
+{
+    public function __invoke(Request $request, PersonalDataExport $export): StreamedJsonResponse
+    {
+        $user = $request->user();
+        $filename = 'lineweb-social-'.$user->handle.'-'.now()->format('Y-m-d').'.json';
+
+        return new StreamedJsonResponse(
+            $export->for($user),
+            headers: [
+                'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+                'X-Content-Type-Options' => 'nosniff',
+                'Cache-Control' => 'private, no-store, max-age=0',
+            ],
+            encodingOptions: JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        );
+    }
+}

--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Account\AccountDeletion;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\ProfileDeleteRequest;
 use App\Http\Requests\Settings\ProfileUpdateRequest;
@@ -17,11 +18,18 @@ class ProfileController extends Controller
     /**
      * Show the user's profile settings page.
      */
-    public function edit(Request $request): Response
+    public function edit(Request $request, AccountDeletion $accountDeletion): Response
     {
         return Inertia::render('settings/profile', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => $request->session()->get('status'),
+            'deletionBlockers' => $accountDeletion
+                ->blockersFor($request->user())
+                ->map(fn ($space): array => [
+                    'name' => $space->name,
+                    'manage_url' => route('spaces.manage', $space),
+                ])
+                ->values(),
         ]);
     }
 
@@ -46,13 +54,13 @@ class ProfileController extends Controller
     /**
      * Delete the user's profile.
      */
-    public function destroy(ProfileDeleteRequest $request): RedirectResponse
-    {
-        $user = $request->user();
+    public function destroy(
+        ProfileDeleteRequest $request,
+        AccountDeletion $accountDeletion,
+    ): RedirectResponse {
+        $accountDeletion->delete($request->user());
 
         Auth::logout();
-
-        $user->delete();
 
         $request->session()->invalidate();
         $request->session()->regenerateToken();

--- a/app/Privacy/PersonalDataExport.php
+++ b/app/Privacy/PersonalDataExport.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace App\Privacy;
+
+use App\Models\User;
+use Generator;
+use Illuminate\Support\Facades\DB;
+
+class PersonalDataExport
+{
+    /**
+     * Build the export structure. Large user-owned collections remain lazy so
+     * the HTTP response can stream them without loading the full export.
+     *
+     * @return array<string, mixed>
+     */
+    public function for(User $user): array
+    {
+        $userId = (int) $user->getKey();
+        $preferences = DB::table('notification_preferences')
+            ->where('user_id', $userId)
+            ->first();
+        $preferenceValues = $preferences === null
+            ? [
+                'comment_replies' => true,
+                'content_mentions' => true,
+                'space_moderation' => true,
+            ]
+            : [
+                'comment_replies' => (bool) $preferences->comment_replies,
+                'content_mentions' => (bool) $preferences->content_mentions,
+                'space_moderation' => (bool) $preferences->space_moderation,
+            ];
+
+        return [
+            'export_version' => 1,
+            'generated_at' => now()->toIso8601String(),
+            'account' => [
+                'id' => $userId,
+                'name' => $user->name,
+                'handle' => $user->handle,
+                'headline' => $user->headline,
+                'email' => $user->email,
+                'email_verified_at' => $user->email_verified_at?->toIso8601String(),
+                'bio' => $user->bio,
+                'location' => $user->location,
+                'website_url' => $user->website_url,
+                'profile_visibility' => $user->profile_visibility->value,
+                'is_discoverable' => $user->is_discoverable,
+                'created_at' => $user->created_at?->toIso8601String(),
+                'updated_at' => $user->updated_at?->toIso8601String(),
+            ],
+            'space_memberships' => $this->spaceMemberships($userId),
+            'owned_spaces' => $this->ownedSpaces($userId),
+            'posts' => $this->posts($userId),
+            'comments' => $this->comments($userId),
+            'post_reactions' => $this->postReactions($userId),
+            'saved_posts' => $this->savedPosts($userId),
+            'following' => $this->following($userId),
+            'followers' => $this->followers($userId),
+            'safety_relationships' => $this->safetyRelationships($userId),
+            'direct_messages' => $this->directMessages($userId),
+            'notifications' => $this->notifications($userId),
+            'space_invitation_activity' => $this->spaceInvitationActivity($userId),
+            'moderation_actions' => $this->moderationActions($userId),
+            'submitted_post_reports' => $this->submittedPostReports($userId),
+            'submitted_comment_reports' => $this->submittedCommentReports($userId),
+            'notification_preferences' => $preferenceValues,
+            'security' => [
+                'two_factor_enabled' => filled($user->two_factor_secret),
+                'two_factor_confirmed_at' => $user->two_factor_confirmed_at?->toIso8601String(),
+                'api_tokens' => $this->apiTokens($userId),
+                'passkeys' => $this->passkeys($userId),
+                'sessions' => $this->sessions($userId),
+            ],
+        ];
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function spaceMemberships(int $userId): Generator
+    {
+        $rows = DB::table('space_members')
+            ->join('spaces', 'spaces.id', '=', 'space_members.space_id')
+            ->where('space_members.user_id', $userId)
+            ->orderBy('spaces.id')
+            ->select([
+                'spaces.id',
+                'spaces.name',
+                'spaces.slug',
+                'spaces.visibility',
+                'space_members.role',
+                'space_members.created_at as joined_at',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield [
+                'space_id' => $row->id,
+                'space_name' => $row->name,
+                'space_slug' => $row->slug,
+                'visibility' => $row->visibility,
+                'role' => $row->role,
+                'joined_at' => $row->joined_at,
+            ];
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function ownedSpaces(int $userId): Generator
+    {
+        $rows = DB::table('spaces')
+            ->where('owner_id', $userId)
+            ->orderBy('id')
+            ->select(['id', 'name', 'slug', 'description', 'visibility', 'created_at', 'updated_at'])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function posts(int $userId): Generator
+    {
+        $rows = DB::table('posts')
+            ->join('spaces', 'spaces.id', '=', 'posts.space_id')
+            ->leftJoin('post_media', 'post_media.post_id', '=', 'posts.id')
+            ->where('posts.user_id', $userId)
+            ->orderBy('posts.id')
+            ->select([
+                'posts.id',
+                'spaces.slug as space_slug',
+                'posts.body',
+                'posts.published_at',
+                'posts.edited_at',
+                'posts.hidden_at',
+                'posts.created_at',
+                'posts.updated_at',
+                'post_media.mime_type as media_mime_type',
+                'post_media.width as media_width',
+                'post_media.height as media_height',
+                'post_media.size_bytes as media_size_bytes',
+                'post_media.alt_text as media_alt_text',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            $post = (array) $row;
+            $post['media'] = $row->media_mime_type === null ? null : [
+                'mime_type' => $row->media_mime_type,
+                'width' => $row->media_width,
+                'height' => $row->media_height,
+                'size_bytes' => $row->media_size_bytes,
+                'alt_text' => $row->media_alt_text,
+            ];
+
+            unset(
+                $post['media_mime_type'],
+                $post['media_width'],
+                $post['media_height'],
+                $post['media_size_bytes'],
+                $post['media_alt_text'],
+            );
+
+            yield $post;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function comments(int $userId): Generator
+    {
+        $rows = DB::table('comments')
+            ->join('posts', 'posts.id', '=', 'comments.post_id')
+            ->join('spaces', 'spaces.id', '=', 'posts.space_id')
+            ->where('comments.user_id', $userId)
+            ->orderBy('comments.id')
+            ->select([
+                'comments.id',
+                'comments.post_id',
+                'spaces.slug as space_slug',
+                'comments.body',
+                'comments.published_at',
+                'comments.edited_at',
+                'comments.hidden_at',
+                'comments.created_at',
+                'comments.updated_at',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function postReactions(int $userId): Generator
+    {
+        yield from $this->postReferences('post_reactions', $userId, ['post_reactions.type']);
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function savedPosts(int $userId): Generator
+    {
+        yield from $this->postReferences('post_saves', $userId);
+    }
+
+    /**
+     * @param  list<string>  $extraColumns
+     * @return Generator<int, array<string, mixed>>
+     */
+    private function postReferences(string $table, int $userId, array $extraColumns = []): Generator
+    {
+        $rows = DB::table($table)
+            ->join('posts', 'posts.id', '=', "{$table}.post_id")
+            ->join('spaces', 'spaces.id', '=', 'posts.space_id')
+            ->where("{$table}.user_id", $userId)
+            ->orderBy("{$table}.id")
+            ->select([
+                "{$table}.post_id",
+                'spaces.slug as space_slug',
+                "{$table}.created_at",
+                ...$extraColumns,
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function following(int $userId): Generator
+    {
+        yield from $this->follows($userId, 'follower_id', 'followed_id');
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function followers(int $userId): Generator
+    {
+        yield from $this->follows($userId, 'followed_id', 'follower_id');
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function follows(int $userId, string $ownerColumn, string $relatedColumn): Generator
+    {
+        $rows = DB::table('user_follows')
+            ->join('users', 'users.id', '=', "user_follows.{$relatedColumn}")
+            ->where("user_follows.{$ownerColumn}", $userId)
+            ->orderBy('user_follows.id')
+            ->select(['users.handle', 'user_follows.created_at'])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function safetyRelationships(int $userId): Generator
+    {
+        $rows = DB::table('user_relationships')
+            ->join('users', 'users.id', '=', 'user_relationships.target_id')
+            ->where('user_relationships.actor_id', $userId)
+            ->orderBy('user_relationships.id')
+            ->select(['users.handle', 'user_relationships.type', 'user_relationships.created_at'])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function directMessages(int $userId): Generator
+    {
+        $rows = DB::table('direct_messages')
+            ->join('conversations', 'conversations.id', '=', 'direct_messages.conversation_id')
+            ->join('users as user_one', 'user_one.id', '=', 'conversations.user_one_id')
+            ->join('users as user_two', 'user_two.id', '=', 'conversations.user_two_id')
+            ->where('direct_messages.sender_id', $userId)
+            ->orderBy('direct_messages.id')
+            ->select([
+                'direct_messages.id',
+                'direct_messages.body',
+                'direct_messages.created_at',
+                'conversations.user_one_id',
+                'user_one.handle as user_one_handle',
+                'user_two.handle as user_two_handle',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield [
+                'id' => $row->id,
+                'recipient_handle' => (int) $row->user_one_id === $userId
+                    ? $row->user_two_handle
+                    : $row->user_one_handle,
+                'body' => $row->body,
+                'sent_at' => $row->created_at,
+            ];
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function notifications(int $userId): Generator
+    {
+        $rows = DB::table('notifications')
+            ->where('notifiable_type', User::class)
+            ->where('notifiable_id', $userId)
+            ->orderBy('created_at')
+            ->select(['type', 'read_at', 'created_at'])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function spaceInvitationActivity(int $userId): Generator
+    {
+        $rows = DB::table('space_invitations')
+            ->join('spaces', 'spaces.id', '=', 'space_invitations.space_id')
+            ->where(function ($invitations) use ($userId): void {
+                $invitations
+                    ->where('space_invitations.invited_by', $userId)
+                    ->orWhere('space_invitations.accepted_by', $userId);
+            })
+            ->orderBy('space_invitations.id')
+            ->select([
+                'spaces.slug as space_slug',
+                'space_invitations.invited_by',
+                'space_invitations.accepted_by',
+                'space_invitations.role',
+                'space_invitations.expires_at',
+                'space_invitations.accepted_at',
+                'space_invitations.revoked_at',
+                'space_invitations.created_at',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield [
+                'space_slug' => $row->space_slug,
+                'relationship' => (int) $row->invited_by === $userId ? 'sent' : 'accepted',
+                'role' => $row->role,
+                'expires_at' => $row->expires_at,
+                'accepted_at' => $row->accepted_at,
+                'revoked_at' => $row->revoked_at,
+                'created_at' => $row->created_at,
+            ];
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function moderationActions(int $userId): Generator
+    {
+        $rows = DB::table('space_audit_logs')
+            ->join('spaces', 'spaces.id', '=', 'space_audit_logs.space_id')
+            ->where('space_audit_logs.actor_id', $userId)
+            ->orderBy('space_audit_logs.id')
+            ->select([
+                'spaces.slug as space_slug',
+                'space_audit_logs.action',
+                'space_audit_logs.reason',
+                'space_audit_logs.created_at',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function submittedPostReports(int $userId): Generator
+    {
+        $rows = DB::table('post_reports')
+            ->join('spaces', 'spaces.id', '=', 'post_reports.space_id')
+            ->where('post_reports.reporter_id', $userId)
+            ->orderBy('post_reports.id')
+            ->select([
+                'post_reports.id',
+                'post_reports.post_id',
+                'spaces.slug as space_slug',
+                'post_reports.reason',
+                'post_reports.details',
+                'post_reports.status',
+                'post_reports.reviewed_at',
+                'post_reports.created_at',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function submittedCommentReports(int $userId): Generator
+    {
+        $rows = DB::table('comment_reports')
+            ->join('spaces', 'spaces.id', '=', 'comment_reports.space_id')
+            ->where('comment_reports.reporter_id', $userId)
+            ->orderBy('comment_reports.id')
+            ->select([
+                'comment_reports.id',
+                'comment_reports.comment_id',
+                'spaces.slug as space_slug',
+                'comment_reports.reason',
+                'comment_reports.details',
+                'comment_reports.status',
+                'comment_reports.reviewed_at',
+                'comment_reports.created_at',
+            ])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function apiTokens(int $userId): Generator
+    {
+        $rows = DB::table('personal_access_tokens')
+            ->where('tokenable_type', User::class)
+            ->where('tokenable_id', $userId)
+            ->orderBy('id')
+            ->select(['name', 'abilities', 'last_used_at', 'expires_at', 'created_at'])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield [
+                'name' => $row->name,
+                'abilities' => json_decode((string) $row->abilities, true) ?? [],
+                'last_used_at' => $row->last_used_at,
+                'expires_at' => $row->expires_at,
+                'created_at' => $row->created_at,
+            ];
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function passkeys(int $userId): Generator
+    {
+        $rows = DB::table('passkeys')
+            ->where('user_id', $userId)
+            ->orderBy('id')
+            ->select(['name', 'last_used_at', 'created_at'])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+
+    /** @return Generator<int, array<string, mixed>> */
+    private function sessions(int $userId): Generator
+    {
+        $rows = DB::table('sessions')
+            ->where('user_id', $userId)
+            ->orderBy('last_activity')
+            ->select(['ip_address', 'user_agent', 'last_activity'])
+            ->lazy(500);
+
+        foreach ($rows as $row) {
+            yield (array) $row;
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -110,5 +110,8 @@ class AppServiceProvider extends ServiceProvider
 
         RateLimiter::for('api-token-management', fn (Request $request): Limit => Limit::perMinute(10)
             ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
+
+        RateLimiter::for('personal-data-export', fn (Request $request): Limit => Limit::perHour(3)
+            ->by((string) ($request->user()?->getAuthIdentifier() ?? $request->ip())));
     }
 }

--- a/docs/privacy-and-data-rights.md
+++ b/docs/privacy-and-data-rights.md
@@ -1,0 +1,73 @@
+# Privacy and data rights
+
+Lineweb Social provides a technical baseline for member data access and
+self-service account deletion. Deployers remain responsible for their own
+privacy notice, retention schedule, legal basis, processor agreements, backup
+lifecycle, and response process. These features are not a compliance
+certification.
+
+## Personal data export
+
+Verified members can download a JSON export from Profile settings after recent
+password confirmation. The route is rate limited and returns a private,
+non-cacheable streamed response.
+
+The export currently includes:
+
+- profile and account fields;
+- Space memberships and owned Space metadata;
+- posts, safe image metadata, comments, reactions, saves, follows, and safety
+  relationships;
+- messages authored by the member;
+- notification metadata and notification preferences;
+- invitation and moderation activity without recipient addresses or internal
+  audit context;
+- reports submitted by the member; and
+- safe security metadata for two-factor state, API tokens, passkeys, and active
+  sessions.
+
+Collections are emitted in chunks and are not capped. A large account therefore
+does not silently receive only the first page of its content.
+
+The export deliberately excludes:
+
+- password hashes, two-factor secrets and recovery codes;
+- API token digests, passkey credentials, invitation token hashes, and session
+  identifiers or payloads;
+- private storage paths, media checksums, and original filenames;
+- messages authored by another participant; and
+- internal notification payloads, reviewer identities, and private moderation
+  context.
+
+Extensions that store member data must add their own export section or document
+why the data is not portable. Do not place extension secrets or unrelated
+third-party personal data in the core export.
+
+## Account deletion
+
+Account deletion requires the current password. On successful deletion, the
+member is logged out, their session is invalidated, API tokens and notifications
+are removed, and user-owned records are removed through the database ownership
+rules. Private post media owned by the account is deleted from configured
+storage.
+
+An account cannot be deleted while it owns a Space that contains another
+member or another person's community activity, including content, moderation
+records, or invitations. The Profile settings page links to each blocking Space
+so ownership can be transferred first. The same condition is rechecked inside
+the deletion transaction to protect against a stale browser page.
+
+A sole-owner Space with no other person's content is deleted with the account.
+This is intentional, but deployers should make the consequence clear in their
+own product copy.
+
+## Operator responsibilities
+
+Application deletion does not erase independent backups, infrastructure logs,
+mail-provider records, analytics, or data copied to an extension or external
+processor. A deployed service needs documented retention and deletion
+procedures for every such system.
+
+Before adding analytics, advertising, AI processing, or third-party exports,
+map the new data flow and update both this contract and the deployer's public
+privacy information.

--- a/resources/js/components/delete-user.tsx
+++ b/resources/js/components/delete-user.tsx
@@ -1,4 +1,5 @@
-import { Form } from '@inertiajs/react';
+import { Form, Link } from '@inertiajs/react';
+import { ArrowUpRight } from 'lucide-react';
 import { useRef } from 'react';
 import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
 import Heading from '@/components/heading';
@@ -16,8 +17,18 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 
-export default function DeleteUser() {
+type DeletionBlocker = {
+    name: string;
+    manage_url: string;
+};
+
+export default function DeleteUser({
+    deletionBlockers,
+}: {
+    deletionBlockers: DeletionBlocker[];
+}) {
     const passwordInput = useRef<HTMLInputElement>(null);
+    const isBlocked = deletionBlockers.length > 0;
 
     return (
         <div className="space-y-6">
@@ -34,11 +45,37 @@ export default function DeleteUser() {
                     </p>
                 </div>
 
+                {isBlocked && (
+                    <div className="rounded-xl border border-red-200 bg-background/70 p-3.5 text-sm text-foreground dark:border-red-200/15">
+                        <p className="font-bold">
+                            Transfer these active Spaces before deleting your
+                            account:
+                        </p>
+                        <ul className="mt-2 space-y-1.5">
+                            {deletionBlockers.map((space) => (
+                                <li key={space.manage_url}>
+                                    <Link
+                                        href={space.manage_url}
+                                        className="social-focus inline-flex items-center gap-1 rounded-md font-semibold text-primary hover:underline"
+                                    >
+                                        {space.name}
+                                        <ArrowUpRight
+                                            className="size-3.5"
+                                            aria-hidden="true"
+                                        />
+                                    </Link>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+
                 <Dialog>
                     <DialogTrigger asChild>
                         <Button
                             variant="destructive"
                             data-test="delete-user-button"
+                            disabled={isBlocked}
                         >
                             Delete account
                         </Button>
@@ -82,6 +119,7 @@ export default function DeleteUser() {
                                         />
 
                                         <InputError message={errors.password} />
+                                        <InputError message={errors.account} />
                                     </div>
 
                                     <DialogFooter className="gap-2">

--- a/resources/js/components/personal-data-controls.tsx
+++ b/resources/js/components/personal-data-controls.tsx
@@ -1,0 +1,54 @@
+import { Download, FileJson, LockKeyhole } from 'lucide-react';
+import Heading from '@/components/heading';
+import { Button } from '@/components/ui/button';
+
+export default function PersonalDataControls() {
+    return (
+        <div className="space-y-6">
+            <Heading
+                variant="small"
+                title="Your data"
+                description="Take a portable copy of the account data and content you created."
+            />
+
+            <div className="overflow-hidden rounded-2xl border bg-muted/20">
+                <div className="flex items-start gap-4 p-4 sm:p-5">
+                    <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                        <FileJson className="size-5" aria-hidden="true" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                        <h3 className="font-extrabold tracking-tight">
+                            Download JSON export
+                        </h3>
+                        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                            Includes your profile, memberships, posts, comments,
+                            reactions, follows, sent messages, reports, and safe
+                            security metadata.
+                        </p>
+                    </div>
+                </div>
+
+                <div className="flex flex-col gap-3 border-t bg-background/60 p-4 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="flex items-center gap-2 text-xs leading-5 text-muted-foreground">
+                        <LockKeyhole
+                            className="size-3.5 shrink-0"
+                            aria-hidden="true"
+                        />
+                        Password confirmation is required. Secrets and messages
+                        sent by other people are excluded.
+                    </p>
+                    <Button
+                        asChild
+                        variant="outline"
+                        className="shrink-0 rounded-full"
+                    >
+                        <a href="/settings/data-export">
+                            <Download className="size-4" aria-hidden="true" />
+                            Download data
+                        </a>
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -11,6 +11,7 @@ import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileCo
 import DeleteUser from '@/components/delete-user';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
+import PersonalDataControls from '@/components/personal-data-controls';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -44,9 +45,11 @@ const visibilityOptions = [
 export default function Profile({
     mustVerifyEmail,
     status,
+    deletionBlockers,
 }: {
     mustVerifyEmail: boolean;
     status?: string;
+    deletionBlockers: Array<{ name: string; manage_url: string }>;
 }) {
     const { auth } = usePage<PageProps>().props;
     const user = auth.user;
@@ -383,7 +386,8 @@ export default function Profile({
                     )}
                 </Form>
             </div>
-            <DeleteUser />
+            <PersonalDataControls />
+            <DeleteUser deletionBlockers={deletionBlockers} />
         </>
     );
 }

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Settings\ApiTokenController;
 use App\Http\Controllers\Settings\NotificationPreferencesController;
+use App\Http\Controllers\Settings\PersonalDataExportController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SafetyController;
 use App\Http\Controllers\Settings\SecurityController;
@@ -17,6 +18,9 @@ Route::middleware(['auth'])->group(function () {
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('settings/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::get('settings/data-export', PersonalDataExportController::class)
+        ->middleware([RequirePassword::class, 'throttle:personal-data-export'])
+        ->name('personal-data.export');
 
     Route::get('settings/security', [SecurityController::class, 'edit'])
         ->middleware(RequirePassword::class)

--- a/tests/Feature/Settings/PersonalDataExportTest.php
+++ b/tests/Feature/Settings/PersonalDataExportTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\DirectMessage;
+use App\Models\NotificationPreference;
+use App\Models\Post;
+use App\Models\Space;
+use App\Models\SpaceInvitation;
+use App\Models\User;
+use App\Models\UserFollow;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class PersonalDataExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_verified_member_with_recent_password_confirmation_can_download_their_data(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Andrew Matia',
+            'handle' => 'andrew-matia',
+            'email' => 'andrew@example.com',
+            'two_factor_secret' => 'private-two-factor-secret',
+            'two_factor_recovery_codes' => 'private-recovery-codes',
+        ]);
+        $other = User::factory()->create(['handle' => 'community-member']);
+        $space = Space::factory()->for($other, 'owner')->create(['slug' => 'makers-circle']);
+        $space->addMember($user);
+
+        $post = Post::factory()->create([
+            'space_id' => $space->getKey(),
+            'user_id' => $user->getKey(),
+            'body' => 'My exported post',
+        ]);
+        Comment::factory()->create([
+            'post_id' => $post->getKey(),
+            'user_id' => $user->getKey(),
+            'body' => 'My exported comment',
+        ]);
+
+        UserFollow::query()->create([
+            'follower_id' => $user->getKey(),
+            'followed_id' => $other->getKey(),
+        ]);
+        NotificationPreference::query()->create([
+            'user_id' => $user->getKey(),
+            'comment_replies' => false,
+            'content_mentions' => true,
+            'space_moderation' => true,
+        ]);
+
+        $conversation = Conversation::between($user, $other);
+        DirectMessage::query()->create([
+            'conversation_id' => $conversation->getKey(),
+            'sender_id' => $user->getKey(),
+            'body' => 'My exported message',
+        ]);
+        DirectMessage::query()->create([
+            'conversation_id' => $conversation->getKey(),
+            'sender_id' => $other->getKey(),
+            'body' => 'Someone else private message',
+        ]);
+
+        $token = $user->createToken(
+            'My phone',
+            ['profile:read'],
+            now()->addDays(30),
+        );
+        SpaceInvitation::query()->create([
+            'space_id' => $space->getKey(),
+            'invited_by' => $user->getKey(),
+            'email' => 'private-recipient@example.com',
+            'role' => 'member',
+            'token_hash' => hash('sha256', 'private-invitation-token'),
+            'expires_at' => now()->addWeek(),
+        ]);
+        DB::table('notifications')->insert([
+            'id' => (string) Str::uuid(),
+            'type' => 'content.mentioned',
+            'notifiable_type' => User::class,
+            'notifiable_id' => $user->getKey(),
+            'data' => json_encode(['actor_id' => $other->getKey()], JSON_THROW_ON_ERROR),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->get(route('personal-data.export'));
+
+        $response
+            ->assertOk()
+            ->assertHeader('content-type', 'application/json')
+            ->assertHeader('content-disposition');
+
+        $content = $response->streamedContent();
+        $export = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $export['export_version']);
+        $this->assertSame('andrew@example.com', $export['account']['email']);
+        $this->assertSame('makers-circle', $export['space_memberships'][0]['space_slug']);
+        $this->assertSame('My exported post', $export['posts'][0]['body']);
+        $this->assertSame('My exported comment', $export['comments'][0]['body']);
+        $this->assertSame('community-member', $export['following'][0]['handle']);
+        $this->assertSame('My exported message', $export['direct_messages'][0]['body']);
+        $this->assertSame('My phone', $export['security']['api_tokens'][0]['name']);
+        $this->assertFalse($export['notification_preferences']['comment_replies']);
+        $this->assertSame('sent', $export['space_invitation_activity'][0]['relationship']);
+        $this->assertSame('content.mentioned', $export['notifications'][0]['type']);
+
+        $this->assertStringNotContainsString('Someone else private message', $content);
+        $this->assertStringNotContainsString('private-recipient@example.com', $content);
+        $this->assertStringNotContainsString(hash('sha256', 'private-invitation-token'), $content);
+        $this->assertStringNotContainsString('private-two-factor-secret', $content);
+        $this->assertStringNotContainsString('private-recovery-codes', $content);
+        $this->assertStringNotContainsString($user->password, $content);
+        $this->assertStringNotContainsString($token->accessToken->token, $content);
+    }
+
+    public function test_data_export_requires_a_verified_account_and_recent_password_confirmation(): void
+    {
+        $unverified = User::factory()->unverified()->create();
+
+        $this->actingAs($unverified)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->get(route('personal-data.export'))
+            ->assertRedirect(route('verification.notice'));
+
+        $this->flushSession();
+        $verified = User::factory()->create();
+
+        $this->actingAs($verified)
+            ->get(route('personal-data.export'))
+            ->assertRedirect(route('password.confirm'));
+    }
+
+    public function test_data_export_does_not_silently_truncate_authored_content(): void
+    {
+        $user = User::factory()->create();
+        $space = Space::factory()->for($user, 'owner')->create();
+        Post::factory()->count(525)->create([
+            'space_id' => $space->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->withSession(['auth.password_confirmed_at' => time()])
+            ->get(route('personal-data.export'));
+
+        $export = json_decode(
+            $response->streamedContent(),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertCount(525, $export['posts']);
+    }
+}

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Feature\Settings;
 
 use App\Enums\ProfileVisibility;
+use App\Models\Post;
+use App\Models\Space;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class ProfileUpdateTest extends TestCase
@@ -135,6 +138,76 @@ class ProfileUpdateTest extends TestCase
             ->assertRedirect(route('profile.edit'));
 
         $this->assertNotNull($user->fresh());
+    }
+
+    public function test_owner_cannot_delete_their_account_while_a_space_has_other_members(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $space = Space::factory()->for($owner, 'owner')->create([
+            'name' => 'Makers Circle',
+            'slug' => 'makers-circle',
+        ]);
+        $space->addMember($member);
+        $memberPost = Post::factory()->create([
+            'space_id' => $space->getKey(),
+            'user_id' => $member->getKey(),
+        ]);
+
+        $this->actingAs($owner)
+            ->from(route('profile.edit'))
+            ->delete(route('profile.destroy'), ['password' => 'password'])
+            ->assertSessionHasErrors('account')
+            ->assertRedirect(route('profile.edit'));
+
+        $this->assertAuthenticatedAs($owner);
+        $this->assertNotNull($owner->fresh());
+        $this->assertNotNull($space->fresh());
+        $this->assertNotNull($memberPost->fresh());
+
+        $this->actingAs($owner)
+            ->get(route('profile.edit'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('settings/profile')
+                ->has('deletionBlockers', 1)
+                ->where('deletionBlockers.0.name', 'Makers Circle')
+                ->where('deletionBlockers.0.manage_url', route('spaces.manage', $space)));
+    }
+
+    public function test_owner_can_delete_their_account_when_owned_spaces_have_no_other_members(): void
+    {
+        $owner = User::factory()->create();
+        $space = Space::factory()->for($owner, 'owner')->create();
+
+        $this->actingAs($owner)
+            ->delete(route('profile.destroy'), ['password' => 'password'])
+            ->assertSessionHasNoErrors()
+            ->assertRedirect(route('home'));
+
+        $this->assertGuest();
+        $this->assertNull($owner->fresh());
+        $this->assertNull($space->fresh());
+    }
+
+    public function test_former_member_content_still_blocks_owner_account_deletion(): void
+    {
+        $owner = User::factory()->create();
+        $formerMember = User::factory()->create();
+        $space = Space::factory()->for($owner, 'owner')->create();
+        $space->addMember($formerMember);
+        $post = Post::factory()->create([
+            'space_id' => $space->getKey(),
+            'user_id' => $formerMember->getKey(),
+        ]);
+        $space->members()->detach($formerMember);
+
+        $this->actingAs($owner)
+            ->from(route('profile.edit'))
+            ->delete(route('profile.destroy'), ['password' => 'password'])
+            ->assertSessionHasErrors('account');
+
+        $this->assertNotNull($owner->fresh());
+        $this->assertNotNull($post->fresh());
     }
 
     /** @param  array<string, mixed>  $overrides */


### PR DESCRIPTION
## Why

Members need a practical way to take their data with them and close an account without accidentally removing an active community owned by other people too.

## What changed

- adds a password-confirmed, rate-limited streamed JSON export covering account, community, authored content, interactions, sent messages, reports, notifications, and safe security metadata
- explicitly excludes credentials, token digests, private storage details, other participants' messages, and unrelated third-party data
- blocks account deletion while an owned Space contains another person's membership or community activity, with direct ownership-transfer links
- rechecks deletion blockers inside the transaction before removing the account
- documents the export boundary and operator retention responsibilities

## Validation

- Full CI: 197 tests, 2,164 assertions; Pint, PHPStan, ESLint, Prettier, and TypeScript passed
- Production frontend build passed
- Composer and npm production dependency audits found no vulnerabilities
- Desktop and 390px mobile browser QA covered Profile settings, deletion blockers, overflow, and password-confirmation navigation
