### PR TITLE
Harden gallery migrations for MariaDB

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,3 +37,54 @@ jobs:
 
       - name: Run CI Checks
         run: composer ci:check
+
+  mariadb-migrations:
+    runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_DATABASE: lineweb_social_test
+          MARIADB_USER: lineweb
+          MARIADB_PASSWORD: lineweb_ci
+          MARIADB_ROOT_PASSWORD: root_ci
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.3'
+          extensions: pdo_mysql
+          tools: composer:v2
+          coverage: none
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Prepare application key
+        run: |
+          cp .env.example .env
+          php artisan key:generate --force --no-interaction
+
+      - name: Run MariaDB migrations
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: lineweb_social_test
+          DB_USERNAME: lineweb
+          DB_PASSWORD: lineweb_ci
+        run: php artisan migrate:fresh --force --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,12 @@ All notable project changes will be documented here.
   timestamps, responsive management dialogs, strict ownership checks, and
   active moderation-review locks.
 
+### Fixed
+
+- Gallery-order migrations now preserve an alternate foreign-key index before
+  replacing the original one-image unique constraint, so clean MariaDB/MySQL
+  installations complete without disabling foreign-key checks.
+
 ### Changed
 
 - Updated `league/commonmark` to 2.9.2 after new denial-of-service and unsafe-link

--- a/database/migrations/2026_07_28_000001_add_gallery_order_to_post_media_table.php
+++ b/database/migrations/2026_07_28_000001_add_gallery_order_to_post_media_table.php
@@ -11,9 +11,15 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('post_media', function (Blueprint $table): void {
-            $table->dropUnique(['post_id']);
             $table->unsignedTinyInteger('position')->default(0)->after('post_id');
+        });
+
+        Schema::table('post_media', function (Blueprint $table): void {
             $table->unique(['post_id', 'position']);
+        });
+
+        Schema::table('post_media', function (Blueprint $table): void {
+            $table->dropUnique(['post_id']);
         });
     }
 
@@ -37,9 +43,12 @@ return new class extends Migration
             });
 
         Schema::table('post_media', function (Blueprint $table): void {
+            $table->unique('post_id');
+        });
+
+        Schema::table('post_media', function (Blueprint $table): void {
             $table->dropUnique(['post_id', 'position']);
             $table->dropColumn('position');
-            $table->unique('post_id');
         });
     }
 };


### PR DESCRIPTION
## Why\n\nA production-shaped MariaDB 10.11 install exposed an index-ordering issue that SQLite cannot reproduce: the gallery migration removed the only index supporting the post_media.post_id foreign key before its replacement existed.\n\n## What changed\n\n- creates the replacement composite index before removing the original unique index\n- preserves the same safe ordering during rollback\n- adds a MariaDB 10.11 migration job so every pull request validates the full schema on the production database family\n\n## Validation\n\n- full local CI: 312 tests / 3,534 assertions, PHPStan, Pint, ESLint, Prettier, and TypeScript\n- clean migration completed against the target server's MariaDB 10.11 database\n- Composer and npm production audits report no known vulnerabilities