### PR TITLE
Bound Vite preload response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@ All notable project changes will be documented here.
 - Gallery-order migrations now preserve an alternate foreign-key index before
   replacing the original one-image unique constraint, so clean MariaDB/MySQL
   installations complete without disabling foreign-key checks.
+- Asset preload response headers are bounded to the eight most important Vite
+  assets so default reverse-proxy buffers can serve every public and auth page
+  without sacrificing critical script, stylesheet, and font preloading.
 
 ### Changed
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -31,7 +31,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             HandleAppearance::class,
             HandleInertiaRequests::class,
-            AddLinkHeadersForPreloadedAssets::class,
+            AddLinkHeadersForPreloadedAssets::using(8),
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -19,6 +19,19 @@ class AuthenticationTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_login_asset_preload_header_stays_within_common_proxy_limits(): void
+    {
+        $response = $this->get(route('login'));
+
+        $response->assertOk();
+
+        $linkHeader = $response->headers->get('Link');
+
+        $this->assertNotNull($linkHeader);
+        $this->assertLessThanOrEqual(8, count(explode(', ', $linkHeader)));
+        $this->assertLessThan(3072, strlen($linkHeader));
+    }
+
     public function test_users_can_authenticate_using_the_login_screen()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Why\n\nThe complete asset preload header reached roughly 6 KB on auth pages and exceeded common default reverse-proxy header buffers, even though the application itself was healthy.\n\n## What changed\n\n- uses Laravel's supported preload middleware limit to send the eight highest-priority assets\n- keeps critical script, stylesheet, and font preloading without requiring hosting-specific buffer changes\n- adds regression coverage for both asset count and total header size\n\n## Validation\n\n- focused auth suite: 7 tests / 18 assertions\n- Pint and diff checks\n- direct production-shaped Apache response: total headers reduced from 7,162 to 2,142 bytes\n- live HTTPS checks for home, login, registration, and health routes all return 200