### PR TITLE
Add baseline browser security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,12 @@ All notable project changes will be documented here.
   assets so default reverse-proxy buffers can serve every public and auth page
   without sacrificing critical script, stylesheet, and font preloading.
 
+### Security
+
+- Public and authenticated responses now deny framing, disable MIME sniffing,
+  use a strict cross-origin referrer policy, and disable unused camera,
+  microphone, and geolocation browser capabilities by default.
+
 ### Changed
 
 - Updated `league/commonmark` to 2.9.2 after new denial-of-service and unsafe-link

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use App\Http\Middleware\EnsureAccountIsActive;
 use App\Http\Middleware\EnsurePlatformAdministrator;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Responses\ApiErrorResponse;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -20,6 +21,8 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->append(SecurityHeaders::class);
+
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
         $middleware->alias([

--- a/tests/Feature/SecurityResponseHeadersTest.php
+++ b/tests/Feature/SecurityResponseHeadersTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityResponseHeadersTest extends TestCase
+{
+    public function test_browser_security_headers_are_applied_to_public_responses(): void
+    {
+        $this->get(route('home'))
+            ->assertOk()
+            ->assertHeader('X-Content-Type-Options', 'nosniff')
+            ->assertHeader('X-Frame-Options', 'DENY')
+            ->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin')
+            ->assertHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+    }
+}


### PR DESCRIPTION
## Why\n\nThe public beta should ship with safe browser defaults in the application itself, independent of a specific nginx or Plesk configuration.\n\n## What changed\n\n- denies framing and MIME sniffing\n- applies a strict cross-origin referrer policy\n- disables unused camera, microphone, and geolocation capabilities\n- covers the complete public response contract with a feature test\n\n## Validation\n\n- focused security and authentication suites: 8 tests / 27 assertions\n- Pint and diff checks\n- existing Plesk-managed HTTPS and six-month HSTS remain enabled