### PR TITLE
Prepare the 0.2.0 public beta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ APP_URL=http://localhost
 
 # Optional PATH_SEPARATOR-delimited roots containing reviewed local extensions.
 LINEWEB_SOCIAL_EXTENSION_PATHS=
-LINEWEB_SOCIAL_CORE_VERSION=0.1.0-alpha.1
+LINEWEB_SOCIAL_CORE_VERSION=0.2.0-beta.1
 LINEWEB_SOCIAL_EXTENSIONS=
 
 APP_LOCALE=en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable project changes will be documented here.
 
 ## Unreleased
 
+## [0.2.0-beta.1] - 2026-08-11
+
 ### Added
 
 - Official Space events with owner/moderator publishing and cancellation,
@@ -177,7 +179,7 @@ All notable project changes will be documented here.
 - Mobile Space cards now begin on the shared 16px content gutter while their
   horizontal scroll rail remains edge-to-edge.
 - The README now presents the project as a product: grouped feature coverage,
-  an experience-led desktop/mobile tour, honest alpha boundaries, a quick-start
+  an experience-led desktop/mobile tour, honest prerelease boundaries, a quick-start
   path, and a navigable map of the public architecture contracts.
 - Long feed posts, comments, and Space-card descriptions now stay compact with
   explicit read-more controls that preserve the complete content on demand.
@@ -241,5 +243,6 @@ All notable project changes will be documented here.
   product-specific presentation and extension-owned capabilities.
 - Feature, authorization, manifest, lint, type, and build checks.
 
-[Unreleased]: https://github.com/drewmt/lineweb-social/compare/v0.1.0-alpha.1...HEAD
+[Unreleased]: https://github.com/drewmt/lineweb-social/compare/v0.2.0-beta.1...HEAD
+[0.2.0-beta.1]: https://github.com/drewmt/lineweb-social/compare/v0.1.0-alpha.1...v0.2.0-beta.1
 [0.1.0-alpha.1]: https://github.com/drewmt/lineweb-social/releases/tag/v0.1.0-alpha.1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
   <p>
     <a href="https://github.com/drewmt/lineweb-social/actions/workflows/tests.yml"><img src="https://github.com/drewmt/lineweb-social/actions/workflows/tests.yml/badge.svg" alt="Tests" /></a>
-    <a href="https://github.com/drewmt/lineweb-social/releases"><img src="https://img.shields.io/badge/release-0.1.0--alpha.1-f97316.svg" alt="Release 0.1.0 alpha 1" /></a>
+    <a href="https://github.com/drewmt/lineweb-social/releases"><img src="https://img.shields.io/badge/release-0.2.0--beta.1-2563eb.svg" alt="Release 0.2.0 beta 1" /></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0--or--later-254ada.svg" alt="GPL 3.0 or later" /></a>
     <img src="https://img.shields.io/badge/Laravel-13-FF2D20.svg?logo=laravel&logoColor=white" alt="Laravel 13" />
     <img src="https://img.shields.io/badge/React-19-087EA4.svg?logo=react&logoColor=white" alt="React 19" />
@@ -493,11 +493,12 @@ is reviewed trusted code, not a sandbox. Remote downloads, arbitrary ZIP
 installation, browser actions, and destructive uninstall are intentionally
 unavailable.
 
-## Alpha status
+## Beta status
 
 > [!IMPORTANT]
-> `0.1.0-alpha.1` is for local evaluation, extension-contract discussion, and
-> early community feedback. It is not a production release.
+> `0.2.0-beta.1` is the first production-shaped public beta. It is suitable for
+> evaluation and controlled community pilots, but it is not a stable `1.0`
+> release and operators should review the documented boundaries below.
 
 The following are deliberately still outside the supported core:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security policy
 
-Lineweb Social is currently available as an early public alpha. Security fixes
-are provided on a best-effort basis for the latest `0.1.x` alpha and the
+Lineweb Social is currently available as a public beta. Security fixes are
+provided on a best-effort basis for the latest `0.2.x` beta and the
 `main` branch only.
 
 Report vulnerabilities through GitHub private vulnerability reporting rather
@@ -13,4 +13,4 @@ Security-sensitive areas include authorization boundaries between spaces, authen
 
 No bounty program or guaranteed response-time commitment exists. Production
 operators should evaluate the code, configure infrastructure securely, and
-track every alpha update until a stable release policy is published.
+track every beta update until a stable release policy is published.

--- a/app/Http/Requests/Concerns/HandlesPostGalleryUploads.php
+++ b/app/Http/Requests/Concerns/HandlesPostGalleryUploads.php
@@ -24,7 +24,7 @@ trait HandlesPostGalleryUploads
             'images.*' => $imageRules,
             'image_alts' => ['nullable', 'array', 'max:'.(int) config('media.max_gallery_items')],
             'image_alts.*' => ['nullable', 'string', 'max:300'],
-            // Kept during the alpha transition for existing clients.
+            // Kept during the legacy gallery transition for existing clients.
             'image' => ['nullable', ...$imageRules],
             'image_alt' => ['nullable', 'string', 'max:300'],
         ];

--- a/config/extensions.php
+++ b/config/extensions.php
@@ -15,7 +15,7 @@ return [
     | support. Keep this value aligned with the public application release.
     |
     */
-    'core_version' => env('LINEWEB_SOCIAL_CORE_VERSION', '0.1.0-alpha.1'),
+    'core_version' => env('LINEWEB_SOCIAL_CORE_VERSION', '0.2.0-beta.1'),
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/media.md
+++ b/docs/media.md
@@ -22,7 +22,7 @@ accessibility, and deletion remain server-enforced platform contracts.
   URLs remain outside the contract.
 
 The legacy single `image` and `image_alt` request fields remain accepted during
-the alpha transition. A legacy draft upload replaces the previous primary
+the legacy gallery transition. A legacy draft upload replaces the previous primary
 image. New clients use `images[]` and `image_alts[]`; requests cannot mix the
 two upload contracts.
 

--- a/extensions/example-polls/extension.json
+++ b/extensions/example-polls/extension.json
@@ -9,7 +9,7 @@
             "url": "https://www.lineweb.gr"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Extensions\\ExamplePolls\\PollsServiceProvider",
     "permissions": [
         "posts.read",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lineweb-social",
-    "version": "0.1.0-alpha.1",
+    "version": "0.2.0-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lineweb-social",
-            "version": "0.1.0-alpha.1",
+            "version": "0.2.0-beta.1",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@inertiajs/react": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://www.schemastore.org/package.json",
     "name": "lineweb-social",
-    "version": "0.1.0-alpha.1",
+    "version": "0.2.0-beta.1",
     "description": "Laravel-native, self-hosted social and community platform foundation.",
     "license": "GPL-3.0-or-later",
     "private": true,

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -339,7 +339,7 @@ export default function Welcome() {
 
                 <footer className="mx-auto flex max-w-[88rem] flex-col gap-2 px-5 py-8 text-xs font-semibold text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:px-8 lg:px-12">
                     <p>Built for communities that want to own their future.</p>
-                    <p>Open-source alpha · GPL-3.0-or-later</p>
+                    <p>Open-source beta · GPL-3.0-or-later</p>
                 </footer>
             </div>
         </>

--- a/tests/Feature/Admin/ExtensionCenterTest.php
+++ b/tests/Feature/Admin/ExtensionCenterTest.php
@@ -39,7 +39,7 @@ class ExtensionCenterTest extends TestCase
             ->get(route('admin.extensions.index'))
             ->assertInertia(fn (Assert $page) => $page
                 ->component('admin/extensions')
-                ->where('coreVersion', '0.1.0-alpha.1')
+                ->where('coreVersion', '0.2.0-beta.1')
                 ->where('summary.discovered', 1)
                 ->where('summary.active', 0)
                 ->where('summary.compatible', 1)
@@ -82,7 +82,7 @@ class ExtensionCenterTest extends TestCase
         $output = Artisan::output();
 
         $this->assertStringContainsString(
-            'Lineweb Social 0.1.0-alpha.1',
+            'Lineweb Social 0.2.0-beta.1',
             $output,
         );
         $this->assertStringContainsString('Example Polls', $output);

--- a/tests/Feature/ExtensionAssetLifecycleTest.php
+++ b/tests/Feature/ExtensionAssetLifecycleTest.php
@@ -32,7 +32,7 @@ class ExtensionAssetLifecycleTest extends TestCase
             $this->extensionRoot,
         );
 
-        config()->set('extensions.core_version', '0.1.0-alpha.1');
+        config()->set('extensions.core_version', '0.2.0-beta.1');
         config()->set('extensions.paths', [$this->extensionRoot]);
         config()->set('extensions.enabled', []);
         config()->set('extensions.assets.public_root', $this->temporaryRoot.'/public');

--- a/tests/Feature/ExtensionMigrationLifecycleTest.php
+++ b/tests/Feature/ExtensionMigrationLifecycleTest.php
@@ -22,7 +22,7 @@ class ExtensionMigrationLifecycleTest extends TestCase
     {
         parent::setUp();
 
-        config()->set('extensions.core_version', '0.1.0-alpha.1');
+        config()->set('extensions.core_version', '0.2.0-beta.1');
         config()->set('extensions.paths', [
             base_path('tests/Fixtures/extension-migrations'),
         ]);

--- a/tests/Fixtures/extension-activation/missing/extension.json
+++ b/tests/Fixtures/extension-activation/missing/extension.json
@@ -8,7 +8,7 @@
             "name": "Lineweb"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Tests\\Fixtures\\ExtensionProviders\\MissingExtensionProvider",
     "permissions": [],
     "ui_slots": []

--- a/tests/Fixtures/extension-activation/not-provider/extension.json
+++ b/tests/Fixtures/extension-activation/not-provider/extension.json
@@ -8,7 +8,7 @@
             "name": "Lineweb"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Tests\\Fixtures\\ExtensionProviders\\NotAServiceProvider",
     "permissions": [],
     "ui_slots": []

--- a/tests/Fixtures/extension-activation/ready/extension.json
+++ b/tests/Fixtures/extension-activation/ready/extension.json
@@ -8,7 +8,7 @@
             "name": "Lineweb"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Tests\\Fixtures\\ExtensionProviders\\ReadyExtensionProvider",
     "permissions": [],
     "ui_slots": []

--- a/tests/Fixtures/extension-activation/throwing/extension.json
+++ b/tests/Fixtures/extension-activation/throwing/extension.json
@@ -8,7 +8,7 @@
             "name": "Lineweb"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Tests\\Fixtures\\ExtensionProviders\\ThrowingExtensionProvider",
     "permissions": [],
     "ui_slots": []

--- a/tests/Fixtures/extension-assets/social-polls/extension.json
+++ b/tests/Fixtures/extension-assets/social-polls/extension.json
@@ -9,7 +9,7 @@
             "url": "https://www.lineweb.gr"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Tests\\Fixtures\\ExtensionProviders\\ReadyExtensionProvider",
     "permissions": [
         "posts.read"

--- a/tests/Fixtures/extension-center/compatible/extension.json
+++ b/tests/Fixtures/extension-center/compatible/extension.json
@@ -8,7 +8,7 @@
             "name": "Lineweb"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Extensions\\Compatible\\CompatibleServiceProvider",
     "permissions": [
         "posts.read"

--- a/tests/Fixtures/extension-center/next-core/extension.json
+++ b/tests/Fixtures/extension-center/next-core/extension.json
@@ -8,7 +8,7 @@
             "name": "Lineweb"
         }
     ],
-    "core": ">=0.2.0",
+    "core": ">=0.3.0",
     "provider": "Extensions\\NextCore\\NextCoreServiceProvider",
     "permissions": [],
     "ui_slots": []

--- a/tests/Fixtures/extension-migrations/polls/extension.json
+++ b/tests/Fixtures/extension-migrations/polls/extension.json
@@ -9,7 +9,7 @@
             "url": "https://www.lineweb.gr"
         }
     ],
-    "core": "^0.1.0-alpha.1",
+    "core": "^0.2.0-beta.1",
     "provider": "Tests\\Fixtures\\ExtensionProviders\\ReadyExtensionProvider",
     "permissions": [
         "posts.read"

--- a/tests/Unit/ExtensionActivatorTest.php
+++ b/tests/Unit/ExtensionActivatorTest.php
@@ -77,7 +77,7 @@ class ExtensionActivatorTest extends TestCase
     /** @param list<string> $enabled */
     private function configure(array $enabled): void
     {
-        config()->set('extensions.core_version', '0.1.0-alpha.1');
+        config()->set('extensions.core_version', '0.2.0-beta.1');
         config()->set('extensions.paths', [
             base_path('tests/Fixtures/extension-activation'),
         ]);

--- a/tests/Unit/ExtensionInspectorTest.php
+++ b/tests/Unit/ExtensionInspectorTest.php
@@ -11,7 +11,7 @@ class ExtensionInspectorTest extends TestCase
 {
     public function test_inspector_isolates_compatible_incompatible_and_invalid_manifests(): void
     {
-        config()->set('extensions.core_version', '0.1.0-alpha.1');
+        config()->set('extensions.core_version', '0.2.0-beta.1');
 
         $inspections = (new ExtensionInspector)->inspect([
             base_path('tests/Fixtures/extension-center'),
@@ -37,14 +37,14 @@ class ExtensionInspectorTest extends TestCase
 
         $this->assertInstanceOf(ExtensionInspection::class, $incompatible);
         $this->assertStringContainsString(
-            'this installation is 0.1.0-alpha.1',
+            'this installation is 0.2.0-beta.1',
             $incompatible->message,
         );
     }
 
     public function test_inspector_marks_every_manifest_that_declares_a_duplicate_id(): void
     {
-        config()->set('extensions.core_version', '0.1.0-alpha.1');
+        config()->set('extensions.core_version', '0.2.0-beta.1');
 
         $inspections = (new ExtensionInspector)->inspect([
             base_path('tests/Fixtures/extensions'),


### PR DESCRIPTION
## Why

Lineweb Social is now running through a production-shaped deployment, so the public metadata should describe the project honestly as a beta rather than an alpha.

## What changed

- set the application and extension contract version to `0.2.0-beta.1`
- update the README, security policy, welcome footer, and changelog
- keep the intentionally incompatible extension fixture on the future `0.3.x` line

## Validation

- `composer ci:check` (314 tests, 3,548 assertions)
- `composer validate --strict`
- `npm run build`
- `npm audit --omit=dev`
- `composer audit --locked`