### PR TITLE
Add safe starter community bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable project changes will be documented here.
 
 ### Added
 
+- An explicit-confirmation, idempotent starter-community command for an
+  existing verified and active member, with a private default Space, three
+  practical starter posts, one highlight, append-only provenance, and no demo
+  credentials, reset endpoint, destructive behavior, or administrator grant.
 - A one-command Docker evaluation environment with MariaDB, queue worker,
   scheduler, generated local secrets, health-gated startup, persistent named
   volumes, least-privilege application containers, and explicit lifecycle and

--- a/README.md
+++ b/README.md
@@ -606,6 +606,20 @@ worker that processes the `notifications` queue (for example,
 `php artisan queue:work --queue=notifications,default`). Read the
 [`notification delivery contract`](docs/notifications.md) before turning it on.
 
+### Bootstrap the first community
+
+After an owner has registered and verified their email, a trusted operator can
+prepare an idempotent private starter Space without creating a shared demo
+account or password:
+
+```bash
+php artisan platform:starter-community owner@example.com --confirm
+```
+
+The starter includes welcome, introductions, and roadmap prompts plus one
+highlighted post. Read the [`starter community contract`](docs/starter-community.md)
+for customization and safety boundaries.
+
 ### Quality checks
 
 ```bash
@@ -625,6 +639,7 @@ only code structure.
 | ------------------------------------------------ | ------------------------------------------------------------------------------------ |
 | Platform boundaries and extension direction      | [`docs/platform-architecture.md`](docs/platform-architecture.md)                     |
 | Reproducible local Docker evaluation              | [`docs/docker.md`](docs/docker.md)                                                     |
+| Idempotent first-community bootstrap              | [`docs/starter-community.md`](docs/starter-community.md)                              |
 | Extension manifests and compatibility inspection | [`docs/extensions.md`](docs/extensions.md)                                           |
 | Extension migration ownership and rollback       | [`docs/extension-migrations.md`](docs/extension-migrations.md)                       |
 | Extension browser assets and integrity           | [`docs/extension-assets.md`](docs/extension-assets.md)                               |

--- a/app/Community/ProvisionStarterCommunity.php
+++ b/app/Community/ProvisionStarterCommunity.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Community;
+
+use App\Enums\SpaceAuditAction;
+use App\Enums\SpaceVisibility;
+use App\Models\Space;
+use App\Models\SpaceAuditLog;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+final class ProvisionStarterCommunity
+{
+    public const BLUEPRINT = 'community-v1';
+
+    private const DESCRIPTION = 'A private starting point for welcoming members, sharing ideas, and shaping the community together.';
+
+    /** @var list<string> */
+    private const POSTS = [
+        'Welcome to the community. Start here: share why this space exists, who it serves, and the behaviours that will keep it useful.',
+        'Introduce yourself: what are you working on, what can you help with, and what would you like to learn from other members?',
+        'Shape the roadmap: share one problem the community should solve next, then use reactions and comments to surface the strongest ideas.',
+    ];
+
+    public function __construct(
+        private readonly CreateSpace $spaces,
+        private readonly PublishPost $posts,
+        private readonly ManageSpaceHighlights $highlights,
+    ) {}
+
+    public function handle(
+        User $owner,
+        string $name,
+        SpaceVisibility $visibility = SpaceVisibility::Private,
+    ): StarterCommunityResult {
+        $name = trim($name);
+
+        if ($name === '') {
+            throw ValidationException::withMessages([
+                'name' => 'Give the starter community a name.',
+            ]);
+        }
+
+        if (mb_strlen($name) > 120) {
+            throw ValidationException::withMessages([
+                'name' => 'Starter community names can be up to 120 characters.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($owner, $name, $visibility): StarterCommunityResult {
+            $lockedOwner = User::query()
+                ->whereKey($owner->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            if (! $lockedOwner->hasVerifiedEmail()) {
+                throw ValidationException::withMessages([
+                    'email' => 'The member must verify their email before receiving a starter community.',
+                ]);
+            }
+
+            if ($lockedOwner->isSuspended()) {
+                throw ValidationException::withMessages([
+                    'account' => 'A suspended member cannot receive a starter community.',
+                ]);
+            }
+
+            $existing = SpaceAuditLog::query()
+                ->with('space')
+                ->where('actor_id', $lockedOwner->getKey())
+                ->where('action', SpaceAuditAction::StarterProvisioned->value)
+                ->where('context->blueprint', self::BLUEPRINT)
+                ->oldest('id')
+                ->first();
+
+            if ($existing?->space instanceof Space) {
+                return new StarterCommunityResult($existing->space, false);
+            }
+
+            $space = $this->spaces->handle(
+                $lockedOwner,
+                $name,
+                self::DESCRIPTION,
+                $visibility,
+            );
+
+            $createdPosts = [];
+
+            foreach (self::POSTS as $body) {
+                $createdPosts[] = $this->posts->publish(
+                    $lockedOwner,
+                    $space,
+                    $body,
+                    [],
+                    [],
+                );
+            }
+
+            $this->highlights->highlight($lockedOwner, $space, $createdPosts[0]);
+
+            SpaceAuditLog::query()->create([
+                'space_id' => $space->getKey(),
+                'actor_id' => $lockedOwner->getKey(),
+                'action' => SpaceAuditAction::StarterProvisioned,
+                'context' => [
+                    'blueprint' => self::BLUEPRINT,
+                    'post_ids' => array_map(
+                        static fn ($post): int => $post->getKey(),
+                        $createdPosts,
+                    ),
+                ],
+            ]);
+
+            return new StarterCommunityResult($space, true);
+        });
+    }
+}

--- a/app/Community/StarterCommunityResult.php
+++ b/app/Community/StarterCommunityResult.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Community;
+
+use App\Models\Space;
+
+final readonly class StarterCommunityResult
+{
+    public function __construct(
+        public Space $space,
+        public bool $created,
+    ) {}
+}

--- a/app/Console/Commands/ProvisionStarterCommunity.php
+++ b/app/Console/Commands/ProvisionStarterCommunity.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Community\ProvisionStarterCommunity as StarterCommunityProvisioner;
+use App\Enums\SpaceVisibility;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\Console\Command\Command as CommandStatus;
+
+class ProvisionStarterCommunity extends Command
+{
+    protected $signature = 'platform:starter-community
+        {email : The existing verified member email address}
+        {--name=Community HQ : The starter Space name}
+        {--visibility=private : public, private, or hidden}
+        {--confirm : Confirm the database writes}';
+
+    protected $description = 'Create an idempotent starter community for an existing member';
+
+    public function handle(StarterCommunityProvisioner $provisioner): int
+    {
+        if (! $this->option('confirm')) {
+            $this->error('Pass --confirm after reviewing the member, name, and visibility.');
+
+            return CommandStatus::FAILURE;
+        }
+
+        $email = Str::lower(trim((string) $this->argument('email')));
+        $member = User::query()->where('email', $email)->first();
+
+        if (! $member instanceof User) {
+            $this->error('No member exists with that email address.');
+
+            return CommandStatus::FAILURE;
+        }
+
+        $visibility = SpaceVisibility::tryFrom(
+            Str::lower(trim((string) $this->option('visibility'))),
+        );
+
+        if (! $visibility instanceof SpaceVisibility) {
+            $this->error('Visibility must be public, private, or hidden.');
+
+            return CommandStatus::FAILURE;
+        }
+
+        try {
+            $result = $provisioner->handle(
+                $member,
+                (string) $this->option('name'),
+                $visibility,
+            );
+        } catch (ValidationException $exception) {
+            $this->error((string) collect($exception->errors())->flatten()->first());
+
+            return CommandStatus::FAILURE;
+        }
+
+        $url = route('spaces.show', $result->space);
+
+        $this->info($result->created
+            ? "Starter community created: {$result->space->name} ({$url})"
+            : "Starter community already exists: {$result->space->name} ({$url})");
+
+        return CommandStatus::SUCCESS;
+    }
+}

--- a/app/Enums/SpaceAuditAction.php
+++ b/app/Enums/SpaceAuditAction.php
@@ -4,6 +4,7 @@ namespace App\Enums;
 
 enum SpaceAuditAction: string
 {
+    case StarterProvisioned = 'starter.provisioned';
     case InvitationSent = 'invitation.sent';
     case InvitationAccepted = 'invitation.accepted';
     case InvitationRevoked = 'invitation.revoked';

--- a/docs/starter-community.md
+++ b/docs/starter-community.md
@@ -1,0 +1,43 @@
+# Starter community bootstrap
+
+Lineweb Social can prepare a useful first Space for an existing member without
+creating shared demo credentials or exposing a setup endpoint. Run the command
+from a trusted application shell after the member has registered and verified
+their email:
+
+```bash
+php artisan platform:starter-community owner@example.com --confirm
+```
+
+The default blueprint creates a private **Community HQ**, makes the member its
+owner, publishes three practical welcome/introductions/roadmap prompts, and adds
+the welcome post to Space highlights. The operation writes an append-only audit
+marker and is idempotent: repeating it for the same member returns the existing
+starter community without duplicating or rewriting content.
+
+The name and visibility can be selected explicitly:
+
+```bash
+php artisan platform:starter-community owner@example.com \
+  --name="Customer Community" \
+  --visibility=private \
+  --confirm
+```
+
+Supported visibility values are `public`, `private`, and `hidden`.
+
+## Safety boundary
+
+- The member must already exist, have a verified email, and have an active
+  account.
+- `--confirm` is always required, including in non-interactive automation.
+- The command creates no user, password, token, API credential, or administrator
+  privilege.
+- It never resets a database, deletes content, or injects posts into an existing
+  unmarked Space.
+- The idempotency marker belongs to the created Space and is removed naturally
+  if that Space is deliberately deleted.
+
+This bootstrap is a starting point, not a permanent product decision. The owner
+can edit or remove the starter posts, invite members, publish new content, and
+shape the community normally after provisioning.

--- a/resources/js/pages/spaces/components/audit-timeline.tsx
+++ b/resources/js/pages/spaces/components/audit-timeline.tsx
@@ -6,6 +6,7 @@ type AuditTimelineProps = {
 };
 
 const actionLabels: Record<string, string> = {
+    'starter.provisioned': 'provisioned the starter community',
     'invitation.sent': 'sent an invitation',
     'invitation.accepted': 'accepted an invitation',
     'invitation.revoked': 'cancelled an invitation',

--- a/tests/Feature/StarterCommunityCommandTest.php
+++ b/tests/Feature/StarterCommunityCommandTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Community\ProvisionStarterCommunity;
+use App\Enums\SpaceAuditAction;
+use App\Enums\SpaceVisibility;
+use App\Models\Post;
+use App\Models\Space;
+use App\Models\SpaceAuditLog;
+use App\Models\SpacePostHighlight;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StarterCommunityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_verified_member_receives_an_audited_starter_community(): void
+    {
+        $member = User::factory()->create(['email' => 'owner@example.com']);
+
+        $this->artisan('platform:starter-community', [
+            'email' => 'OWNER@example.com',
+            '--confirm' => true,
+        ])->assertSuccessful()
+            ->expectsOutputToContain('Starter community created: Community HQ');
+
+        $space = Space::query()->sole();
+
+        $this->assertTrue($space->owner->is($member));
+        $this->assertSame(SpaceVisibility::Private, $space->visibility);
+        $this->assertSame(3, Post::query()->whereBelongsTo($space)->count());
+        $this->assertDatabaseHas('space_members', [
+            'space_id' => $space->getKey(),
+            'user_id' => $member->getKey(),
+            'role' => 'owner',
+        ]);
+
+        $highlight = SpacePostHighlight::query()->sole();
+        $this->assertSame($space->getKey(), $highlight->space_id);
+        $this->assertSame($member->getKey(), $highlight->highlighted_by);
+
+        $audit = SpaceAuditLog::query()
+            ->where('action', SpaceAuditAction::StarterProvisioned->value)
+            ->sole();
+
+        $this->assertSame(ProvisionStarterCommunity::BLUEPRINT, $audit->context['blueprint']);
+        $this->assertCount(3, $audit->context['post_ids']);
+    }
+
+    public function test_repeated_command_returns_the_existing_blueprint_without_duplicates(): void
+    {
+        $member = User::factory()->create(['email' => 'owner@example.com']);
+
+        $this->artisan('platform:starter-community', [
+            'email' => $member->email,
+            '--name' => 'Founders Circle',
+            '--visibility' => 'public',
+            '--confirm' => true,
+        ])->assertSuccessful();
+
+        $this->artisan('platform:starter-community', [
+            'email' => $member->email,
+            '--name' => 'A different name',
+            '--visibility' => 'hidden',
+            '--confirm' => true,
+        ])->assertSuccessful()
+            ->expectsOutputToContain('Starter community already exists: Founders Circle');
+
+        $this->assertSame(1, Space::query()->count());
+        $this->assertSame(3, Post::query()->count());
+        $this->assertSame(1, SpacePostHighlight::query()->count());
+        $this->assertSame(
+            1,
+            SpaceAuditLog::query()
+                ->where('action', SpaceAuditAction::StarterProvisioned->value)
+                ->count(),
+        );
+        $this->assertSame(SpaceVisibility::Public, Space::query()->sole()->visibility);
+    }
+
+    public function test_command_requires_explicit_confirmation(): void
+    {
+        $member = User::factory()->create();
+
+        $this->artisan('platform:starter-community', [
+            'email' => $member->email,
+        ])->assertFailed()
+            ->expectsOutputToContain('Pass --confirm');
+
+        $this->assertDatabaseEmpty('spaces');
+        $this->assertDatabaseEmpty('posts');
+    }
+
+    public function test_unverified_member_cannot_receive_a_starter_community(): void
+    {
+        $member = User::factory()->unverified()->create();
+
+        $this->artisan('platform:starter-community', [
+            'email' => $member->email,
+            '--confirm' => true,
+        ])->assertFailed()
+            ->expectsOutputToContain('must verify their email');
+
+        $this->assertDatabaseEmpty('spaces');
+    }
+
+    public function test_suspended_member_cannot_receive_a_starter_community(): void
+    {
+        $member = User::factory()->create(['suspended_at' => now()]);
+
+        $this->artisan('platform:starter-community', [
+            'email' => $member->email,
+            '--confirm' => true,
+        ])->assertFailed()
+            ->expectsOutputToContain('suspended member');
+
+        $this->assertDatabaseEmpty('spaces');
+    }
+
+    public function test_command_rejects_unknown_visibility_without_writes(): void
+    {
+        $member = User::factory()->create();
+
+        $this->artisan('platform:starter-community', [
+            'email' => $member->email,
+            '--visibility' => 'members-only',
+            '--confirm' => true,
+        ])->assertFailed()
+            ->expectsOutputToContain('Visibility must be public, private, or hidden.');
+
+        $this->assertDatabaseEmpty('spaces');
+    }
+}


### PR DESCRIPTION
## What changed

- Added an explicit-confirmation `platform:starter-community` command for an existing verified, active member.
- Creates a private Community HQ by default with three practical starter posts and one highlighted welcome post.
- Records an append-only blueprint marker so repeated runs return the existing community instead of duplicating content.
- Rejects unverified or suspended members and invalid visibility values before any writes.
- Added a human-readable Space audit label, operator documentation, README onboarding, changelog coverage, and focused regression tests.

## Why

A fresh social installation is technically complete but still empty. This gives Laravel teams a safe first-value path after registration without introducing shared demo passwords, automatic users, a public setup endpoint, destructive resets, or administrator privileges.

## Validation

- `composer run ci:check` — 330 tests, 3,718 assertions
- Focused starter-community suite — 6 tests, 31 assertions
- `npm run build`
- `composer validate --strict`
- `composer audit --locked`
- `npm audit --omit=dev`
- `git diff --check` and explicit public-scope scan